### PR TITLE
Remove fluid tag from the container

### DIFF
--- a/resources/views/kiosk.blade.php
+++ b/resources/views/kiosk.blade.php
@@ -7,7 +7,7 @@
 
 @section('content')
 <spark-kiosk :user="user" inline-template>
-    <div class="container-fluid">
+    <div class="container">
         <div class="row">
             <!-- Tabs -->
             <div class="col-md-4">


### PR DESCRIPTION
Hey,

I saw that on all pages we use ´container`and not`container-fluid` - So i removed it for the kiosk view file.

I'm not sure if it should be merged into 1.0 tag or the master.
# Before

![skaermbillede 2016-04-22 kl 11 46 19](https://cloud.githubusercontent.com/assets/183790/14738548/77564516-0882-11e6-922f-e11dc0194daa.png)
# after

![skaermbillede 2016-04-22 kl 11 46 35](https://cloud.githubusercontent.com/assets/183790/14738556/7f4f7eae-0882-11e6-8163-15014740d6e1.png)
