### PR TITLE
Prevent users without an active subscription from viewing 'your application dashboard'.

### DIFF
--- a/install-stubs/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/install-stubs/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,7 +18,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/home');
+            return redirect('/dashboard');
         }
 
         return $next($request);

--- a/resources/assets/js/auth/register-stripe.js
+++ b/resources/assets/js/auth/register-stripe.js
@@ -189,7 +189,7 @@ module.exports = {
         sendRegistration() {
             Spark.post('/register', this.registerForm)
                 .then(response => {
-                    window.location = '/home';
+                    window.location = '/dashboard';
                 });
         }
     },

--- a/resources/views/nav/blade/user.blade.php
+++ b/resources/views/nav/blade/user.blade.php
@@ -13,7 +13,7 @@
             </div>
 
             <!-- Branding Image -->
-            <a class="navbar-brand" href="/home">
+            <a class="navbar-brand" href="/dashboard">
                 <!-- Spark -->
                 <img src="/img/mono-logo.png" style="height: 32px;">
             </a>

--- a/resources/views/nav/brand.blade.php
+++ b/resources/views/nav/brand.blade.php
@@ -1,3 +1,3 @@
-<a class="navbar-brand" href="/home">
+<a class="navbar-brand" href="/dashboard">
     <img src="/img/mono-logo.png" style="height: 32px;">
 </a>

--- a/resources/views/saas/dashboard.blade.php
+++ b/resources/views/saas/dashboard.blade.php
@@ -1,0 +1,17 @@
+@extends('spark::layouts.app')
+
+@section('content')
+<div class="container">
+    <!-- Application Dashboard -->
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Dashboard</div>
+
+                <div class="panel-body">
+                    Your application's dashboard.
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -23,7 +23,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/dashboard';
 
     /**
      * Create a new login controller instance.

--- a/src/Http/Controllers/Auth/RegisterController.php
+++ b/src/Http/Controllers/Auth/RegisterController.php
@@ -20,7 +20,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/dashboard';
 
     /**
      * Create a new authentication controller instance.

--- a/src/Http/Controllers/SaasController.php
+++ b/src/Http/Controllers/SaasController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Spark\Http\Controllers;
+
+use Parsedown;
+use Laravel\Spark\Spark;
+
+class SaasController extends Controller
+{
+    
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('subscribed');
+    }
+    /**
+     * Show the terms of service for the application.
+     *
+     * @return Response
+     */
+    public function dashboard()
+    {
+        return view('spark::saas.dashboard');
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -2,6 +2,9 @@
 
 $router->group(['middleware' => 'web'], function ($router) {
     // Terms Of Service...
+    $router->get('/dashboard', 'SaasController@dashboard');    
+
+    // Terms Of Service...
     $router->get('/terms', 'TermsController@show');
 
     // Missing Team Notice...


### PR DESCRIPTION
Currently if a user’s subscription is expired they can still view /home
‘your applications dashboard’. Created a new dashboard route/view and
created a SaasController for SaaS app views/pages for subscribed users.
Updated the main nav/default route to /dashboard. Current /home view could be used for the public facing website homepage.
