### PR TITLE
Remove duplicate braintree event listener

### DIFF
--- a/install-stubs/app/Providers/BraintreeEventServiceProvider.php
+++ b/install-stubs/app/Providers/BraintreeEventServiceProvider.php
@@ -27,10 +27,6 @@ class EventServiceProvider extends ServiceProvider
             'Laravel\Spark\Listeners\Profile\UpdateContactInformationOnBraintree',
         ],
 
-        'Laravel\Spark\Events\Profile\ContactInformationUpdated' => [
-            'Laravel\Spark\Listeners\Profile\UpdateContactInformationOnBraintree',
-        ],
-
         'Laravel\Spark\Events\Subscription\SubscriptionUpdated' => [
             'Laravel\Spark\Listeners\Subscription\UpdateActiveSubscription',
         ],


### PR DESCRIPTION
Resolve issue https://github.com/laravel/spark/issues/10 where the same Braintree event listener has been registered twice.
