### PR TITLE
Return all plans.

### DIFF
--- a/src/Http/Controllers/PlanController.php
+++ b/src/Http/Controllers/PlanController.php
@@ -7,12 +7,12 @@ use Laravel\Spark\Spark;
 class PlanController extends Controller
 {
     /**
-     * Get the all of the plans defined for the appliation.
+     * Get the all of the plans defined for the application.
      *
      * @return Response
      */
     public function all()
     {
-        return response()->json(Spark::plans());
+        return response()->json(Spark::allPlans());
     }
 }


### PR DESCRIPTION
Currently its not returning team plans. This will return team and regular plans.

Noticed this when trying to show plans on the register page. The route is set to /spark/plans which will only return regular plans.
