### PR TITLE
Fix issue with new versions of Chart.js

### DIFF
--- a/resources/assets/js/kiosk/metrics.js
+++ b/resources/assets/js/kiosk/metrics.js
@@ -174,9 +174,13 @@ module.exports = {
                 options.scaleLabel = scaleLabelFormatter;
             }
 
-            var chart = new Chart(
-                document.getElementById(id).getContext('2d')
-            ).Line(data, options);
+            var context = document.getElementById(id).getContext('2d')
+
+            var chart = new Chart(context , {
+                data: data,
+                options: options,
+                type: 'line'
+            });
         },
 
 


### PR DESCRIPTION
Fixes an issue that occurs when using new verisions of Chart.js, since their api has changed.

The error: `Uncaught TypeError: (intermediate value).Line is not a function`
