### PR TITLE
Redirect successful registration with response redirect

### DIFF
--- a/resources/assets/js/auth/register-stripe.js
+++ b/resources/assets/js/auth/register-stripe.js
@@ -189,7 +189,7 @@ module.exports = {
         sendRegistration() {
             Spark.post('/register', this.registerForm)
                 .then(response => {
-                    window.location = '/home';
+                    window.location = response.redirect;
                 });
         }
     },


### PR DESCRIPTION
register-braintree.js already use `response.redirect`.
