### PR TITLE
Remove duplicate AnnouncementCreated event

### DIFF
--- a/src/Http/Controllers/Kiosk/AnnouncementController.php
+++ b/src/Http/Controllers/Kiosk/AnnouncementController.php
@@ -56,9 +56,9 @@ class AnnouncementController extends Controller
             'action_url' => 'required_with:action_text',
         ]);
 
-        event(new AnnouncementCreated($this->announcements->create(
+        $this->announcements->create(
             $request->user(), $request->all()
-        )));
+        );
     }
 
     /**


### PR DESCRIPTION
Event is fired from `AnnouncementRepository`. This will now follow same pattern established in `NotificationRepository` with the `NotificationCreated` event.
