### PR TITLE
The deletingAnnouncement object doesn't have a title field

### DIFF
--- a/resources/views/kiosk/announcements.blade.php
+++ b/resources/views/kiosk/announcements.blade.php
@@ -189,7 +189,7 @@
                         <button type="button " class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 
                         <h4 class="modal-title">
-                            Delete Announcement (@{{ deletingAnnouncement.title }})
+                            Delete Announcement
                         </h4>
                     </div>
 


### PR DESCRIPTION
In it's current form, when you click to delete an announcement, the modal pops up with `Deleting Announcement ()`. This is due to the incorrect use of:

```
Delete Announcement (@{{ deletingAnnouncement.title }})
```

The object does not have a title property.
