### PR TITLE
Fix notification view for multiple notifications

### DIFF
--- a/resources/assets/less/components/notifications.less
+++ b/resources/assets/less/components/notifications.less
@@ -4,6 +4,9 @@
         border-bottom: 0;
         margin-bottom: 0;
         height: 70px;
+        width: 100%;
+        position: fixed;
+        z-index: 100;
 
         .btn-group {
             padding-top: 4px;
@@ -34,6 +37,14 @@
         background: #fff;
         border-top: 1px dashed rgba(0,0,0,.1);
         width: 350px;
+    }
+
+    .notification-container:first-child {
+      padding-top: 70px;
+    }
+
+    .notification-container:last-child {
+      padding-bottom: 65px + 23px;
     }
 
     .notification:not(:first-child) {

--- a/resources/views/modals/notifications.blade.php
+++ b/resources/views/modals/notifications.blade.php
@@ -22,11 +22,11 @@
 
                     <div class="modal-body">
                         <!-- Informational Messages -->
-                        <div v-if="loadingNotifications">
+                        <div class="notification-container" v-if="loadingNotifications">
                             <i class="fa fa-btn fa-spinner fa-spin"></i>Loading Notifications
                         </div>
 
-                        <div v-if=" ! loadingNotifications && activeNotifications.length == 0">
+                        <div class="notification-container" v-if=" ! loadingNotifications && activeNotifications.length == 0">
                             <div class="alert alert-warning m-b-none">
                                 We don't have anything to show you right now! But when we do,
                                 we'll be sure to let you know. Talk to you soon!
@@ -34,7 +34,7 @@
                         </div>
 
                         <!-- List Of Notifications -->
-                        <div v-if="showingNotifications && hasNotifications">
+                        <div class="notification-container" v-if="showingNotifications && hasNotifications">
                             <div class="notification" v-for="notification in notifications.notifications">
 
                                 <!-- Notification Icon -->
@@ -79,7 +79,7 @@
                         </div>
 
                         <!-- List Of Announcements -->
-                        <div v-if="showingAnnouncements && hasAnnouncements">
+                        <div class="notification-container" v-if="showingAnnouncements && hasAnnouncements">
                             <div class="notification" v-for="announcement in notifications.announcements">
 
                                 <!-- Notification Icon -->


### PR DESCRIPTION
When more notifications are shown that can fit on the screen, half of
the last notification was previously cut off margin has not been added
to a notification container class to fix this.

The notification / Announcement toggle has now been set to fixed to
allow the notifications to scroll below it so it is always in view.
