### PR TITLE
Fix issue #79 - Trial period notification still shows after subscription.

### DIFF
--- a/install-stubs/app/Providers/EventServiceProvider.php
+++ b/install-stubs/app/Providers/EventServiceProvider.php
@@ -21,6 +21,7 @@ class EventServiceProvider extends ServiceProvider
         'Laravel\Spark\Events\Subscription\UserSubscribed' => [
             'Laravel\Spark\Listeners\Subscription\UpdateActiveSubscription',
             'Laravel\Spark\Listeners\Subscription\UpdateTrialEndingDate',
+            'Laravel\Spark\Listeners\Subscription\RemoveTrialEndingNotification',
         ],
 
         'Laravel\Spark\Events\Profile\ContactInformationUpdated' => [
@@ -51,6 +52,7 @@ class EventServiceProvider extends ServiceProvider
         'Laravel\Spark\Events\Teams\Subscription\TeamSubscribed' => [
             'Laravel\Spark\Listeners\Teams\Subscription\UpdateActiveSubscription',
             'Laravel\Spark\Listeners\Teams\Subscription\UpdateTrialEndingDate',
+            'Laravel\Spark\Listeners\Teams\Subscription\RemoveTrialEndingNotification',
         ],
 
         'Laravel\Spark\Events\Teams\Subscription\SubscriptionUpdated' => [

--- a/install-stubs/database/migrations/create_notifications_table.php
+++ b/install-stubs/database/migrations/create_notifications_table.php
@@ -21,6 +21,7 @@ class CreateNotificationsTable extends Migration
             $table->string('action_text')->nullable();
             $table->text('action_url')->nullable();
             $table->tinyInteger('read')->default(0);
+            $table->string('event')->nullable();
             $table->timestamps();
 
             $table->index(['user_id', 'created_at']);

--- a/src/Listeners/Subscription/CreateTrialEndingNotification.php
+++ b/src/Listeners/Subscription/CreateTrialEndingNotification.php
@@ -43,6 +43,7 @@ class CreateTrialEndingNotification
             'body' => 'Your trial period will expire on '.$event->user->trial_ends_at->format('F jS').'.',
             'action_text' => 'Subscribe',
             'action_url' => '/settings#/subscription',
+            'event' => 'UserRegistered',
         ]);
     }
 }

--- a/src/Listeners/Subscription/RemoveTrialEndingNotification.php
+++ b/src/Listeners/Subscription/RemoveTrialEndingNotification.php
@@ -3,8 +3,8 @@
 namespace Laravel\Spark\Listeners\Subscription;
 
 use Laravel\Spark\Spark;
+use Laravel\Spark\Notification;
 use Laravel\Spark\Events\Subscription\UserSubscribed;
-use Laravel\Spark\Contracts\Repositories\NotificationRepository;
 
 class RemoveTrialEndingNotification
 {

--- a/src/Listeners/Subscription/RemoveTrialEndingNotification.php
+++ b/src/Listeners/Subscription/RemoveTrialEndingNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Spark\Listeners\Subscription;
+
+use Laravel\Spark\Spark;
+use Laravel\Spark\Events\Subscription\UserSubscribed;
+use Laravel\Spark\Contracts\Repositories\NotificationRepository;
+
+class RemoveTrialEndingNotification
+{
+    /**
+     * Handle the event.
+     *
+     * @param  UserSubscribed  $event
+     * @return void
+     */
+    public function handle(UserSubscribed $event)
+    {
+        if (! Spark::trialDays()) {
+            return;
+        }
+
+        $notification = Notification::where('user_id', $event->user->id)
+                      ->where('event', 'UserRegistered')
+                      ->first()
+                      ->delete();
+    }
+}

--- a/src/Listeners/Teams/CreateInvitationNotification.php
+++ b/src/Listeners/Teams/CreateInvitationNotification.php
@@ -38,6 +38,7 @@ class CreateInvitationNotification
             'body' => 'You have been invited to join the '.$event->team->name.' team!',
             'action_text' => 'View Invitations',
             'action_url' => '/settings#/teams',
+            'event' => 'UserInvitedToTeam',
         ]);
     }
 }

--- a/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
+++ b/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
@@ -43,6 +43,7 @@ class CreateTrialEndingNotification
             'body' => "The ".$event->team->name." team's trial period will expire on ".$event->team->trial_ends_at->format('F jS').'.',
             'action_text' => 'Subscribe',
             'action_url' => '/settings/teams/'.$event->team->id.'#/subscription',
+            'event' => 'TeamRegistered',
         ]);
     }
 }

--- a/src/Listeners/Teams/Subscription/RemoveTrialEndingNotification.php
+++ b/src/Listeners/Teams/Subscription/RemoveTrialEndingNotification.php
@@ -6,7 +6,7 @@ use Laravel\Spark\Spark;
 use Laravel\Spark\Events\Teams\Subscription\TeamSubscribed;
 use Laravel\Spark\Contracts\Repositories\NotificationRepository;
 
-class CreateTrialEndingNotification
+class RemoveTrialEndingNotification
 {
     /**
      * Handle the event.

--- a/src/Listeners/Teams/Subscription/RemoveTrialEndingNotification.php
+++ b/src/Listeners/Teams/Subscription/RemoveTrialEndingNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Spark\Listeners\Teams\Subscription;
+
+use Laravel\Spark\Spark;
+use Laravel\Spark\Events\Teams\Subscription\TeamSubscribed;
+use Laravel\Spark\Contracts\Repositories\NotificationRepository;
+
+class CreateTrialEndingNotification
+{
+    /**
+     * Handle the event.
+     *
+     * @param  TeamSubscribed  $event
+     * @return void
+     */
+    public function handle(TeamSubscribed $event)
+    {
+        if (! Spark::teamTrialDays()) {
+            return;
+        }
+
+        $notification = Notification::where('user_id', $event->team->owner->id)
+                      ->where('event', 'TeamRegistered')
+                      ->first()
+                      ->delete();
+    }
+}

--- a/src/Listeners/Teams/Subscription/RemoveTrialEndingNotification.php
+++ b/src/Listeners/Teams/Subscription/RemoveTrialEndingNotification.php
@@ -3,8 +3,8 @@
 namespace Laravel\Spark\Listeners\Teams\Subscription;
 
 use Laravel\Spark\Spark;
+use Laravel\Spark\Notification;
 use Laravel\Spark\Events\Teams\Subscription\TeamSubscribed;
-use Laravel\Spark\Contracts\Repositories\NotificationRepository;
 
 class RemoveTrialEndingNotification
 {

--- a/src/Repositories/NotificationRepository.php
+++ b/src/Repositories/NotificationRepository.php
@@ -42,6 +42,7 @@ class NotificationRepository implements NotificationRepositoryContract
             'body' => $data['body'],
             'action_text' => array_get($data, 'action_text'),
             'action_url' => array_get($data, 'action_url'),
+            'event' => $data['event'] ? $data['event'] : null,
         ]);
 
         event(new NotificationCreated($notification));


### PR DESCRIPTION
Fixes Issue #79  - Trial period notification still shows after subscription.

Add new column to notifications table to store the event the
notification is related to. This is used to track down a notification
at a later date which was generated for a specific event.

Update CreateTrialEndingNotification for single users and teams to
complete the event column on the notification.

Update CreateInvitationNotification for teams to complete the event
column on the notification.

Create RemoveTrialEndingNotification for single users and teams to
remove the Trial Ending Notification create at registration.
