### PR TITLE
Refactor the global spark object

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,9 +21,8 @@
 
     <!-- Global Spark Object -->
     <script>
-        window.Spark = <?php echo json_encode(array_merge(
-            Spark::scriptVariables(), []
-        )); ?>
+        window.Spark = {!! json_encode(Spark::scriptVariables()) !!}
+        @stack('global-spark-objects')
     </script>
 </head>
 <body class="with-navbar" v-cloak>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,7 +21,7 @@
 
     <!-- Global Spark Object -->
     <script>
-        window.Spark = {!! json_encode(Spark::scriptVariables()) !!}
+        window.Spark = {!! json_encode(Spark::scriptVariables()) !!};
         @stack('global-spark-objects')
     </script>
 </head>

--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -26,6 +26,7 @@ trait ProvidesScriptVariables
             'csrfToken' => csrf_token(),
             'currencySymbol' => Cashier::usesCurrencySymbol(),
             'env' => config('app.env'),
+            'injectedObjects' => [],
             'roles' => Spark::roles(),
             'state' => Spark::call(InitialFrontendState::class.'@forUser', [Auth::user()]),
             'stripeKey' => config('services.stripe.key'),


### PR DESCRIPTION
Fixes #87

**Description**
- Change the inclusion of the scriptVariables() to use blade syntax
- Create a new object in the spark global object called ‘injectedObjects’ this will hold all of the objects a developer wants to inject on page load.
- Create a blade stack to allow developers to push objects into the global spark object from any sub view, this ensures the objects are only created for that sub view.

**Objects can be injected to a sub view like so:**

```
@push('global-spark-objects')
    window.Spark.injectedObjects.newObject = {!! json_encode(['newObject']) !!};
@endpush
```
