### PR TITLE
Billing: Validate state name and abbreviation

### DIFF
--- a/src/Validation/StateValidator.php
+++ b/src/Validation/StateValidator.php
@@ -35,9 +35,10 @@ class StateValidator
             return true;
         }
 
-        $abbreviations = $this->states->forCountry($parameters[0])
-                                ->pluck('abbreviation')->all();
+        $abbreviations = $this->states->forCountry($parameters[0])->flatten()->map(function ($item, $key) {
+            return strtoupper($item);
+        })->all();
 
-        return empty($abbreviations) || in_array($value, $abbreviations);
+        return empty($abbreviations) || in_array(strtoupper($value), $abbreviations);
     }
 }

--- a/src/Validation/StateValidator.php
+++ b/src/Validation/StateValidator.php
@@ -35,10 +35,10 @@ class StateValidator
             return true;
         }
 
-        $abbreviations = $this->states->forCountry($parameters[0])->flatten()->map(function ($item, $key) {
+        $states = $this->states->forCountry($parameters[0])->flatten()->map(function ($item, $key) {
             return strtoupper($item);
         })->all();
 
-        return empty($abbreviations) || in_array(strtoupper($value), $abbreviations);
+        return empty($states) || in_array(strtoupper($value), $states);
     }
 }


### PR DESCRIPTION
Spark doesn't currently validate state names only the abbreviation, resulting in:

![ember library mediator](https://cloud.githubusercontent.com/assets/1422996/15667245/2ce9c21a-270d-11e6-9af3-ff14cde1ca00.png)
