### PR TITLE
SendSupportEmail: Add "from" to message

### DIFF
--- a/src/Interactions/Support/SendSupportEmail.php
+++ b/src/Interactions/Support/SendSupportEmail.php
@@ -37,6 +37,7 @@ class SendSupportEmail implements Contract
         Mail::raw($data['message'], function ($m) use ($data) {
             $m->to(Spark::supportAddress())->subject('Support Request: '.$data['subject']);
 
+            $m->from($data['from']);
             $m->replyTo($data['from']);
         });
     }


### PR DESCRIPTION
For now, mail client shows "No Sender". Adding email to "From" would be helpful.
