### PR TITLE
Reset notifications key after sortBy('created_at')

### DIFF
--- a/src/Repositories/NotificationRepository.php
+++ b/src/Repositories/NotificationRepository.php
@@ -39,7 +39,7 @@ class NotificationRepository implements NotificationRepositoryContract
                         ->delete();
         }
 
-        return $notifications;
+        return $notifications->values();
     }
 
     /**


### PR DESCRIPTION
This will resolve issue https://github.com/laravel/spark/issues/107

Where multiple personal notifications will not show in notification modal
