### PR TITLE
Added table-response class to wrapping div

### DIFF
--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -28,7 +28,7 @@
         <div class="clearfix"></div>
     </div>
 
-    <div class="panel-body">
+    <div class="panel-body table-responsive">
         <!-- Subscription Notice -->
         <div class="p-b-lg">
             You are not subscribed to a plan. Choose from the plans below to get started.


### PR DESCRIPTION
Add table-responsive class to subscribe-common.blade.php file, this now matches the behaviour of the subscribe-stripe.blade.php view.

Fixes: #115 
