### PR TITLE
Update SendSupportEmail.php

### DIFF
--- a/src/Interactions/Support/SendSupportEmail.php
+++ b/src/Interactions/Support/SendSupportEmail.php
@@ -36,7 +36,10 @@ class SendSupportEmail implements Contract
 
         Mail::raw($data['message'], function ($m) use ($data) {
             $m->to(Spark::supportAddress())->subject('Support Request: '.$data['subject']);
-            $m->from($data['from']);
+            
+            if (isset($data['from']))
+                $m->from($data['from']);
+            
             $m->replyTo($data['from']);
         });
     }

--- a/src/Interactions/Support/SendSupportEmail.php
+++ b/src/Interactions/Support/SendSupportEmail.php
@@ -36,7 +36,7 @@ class SendSupportEmail implements Contract
 
         Mail::raw($data['message'], function ($m) use ($data) {
             $m->to(Spark::supportAddress())->subject('Support Request: '.$data['subject']);
-
+            $m->from($data['from']);
             $m->replyTo($data['from']);
         });
     }

--- a/src/Interactions/Support/SendSupportEmail.php
+++ b/src/Interactions/Support/SendSupportEmail.php
@@ -37,8 +37,9 @@ class SendSupportEmail implements Contract
         Mail::raw($data['message'], function ($m) use ($data) {
             $m->to(Spark::supportAddress())->subject('Support Request: '.$data['subject']);
             
-            if (isset($data['from']))
+            if (isset($data['from'])) {
                 $m->from($data['from']);
+            }
             
             $m->replyTo($data['from']);
         });


### PR DESCRIPTION
Added the from field to the e-mail message because, without it, SwiftMailer's AbstractSmtpTransport class gives an exception at line 162 with the message 'Cannot send message without a sender address' when trying to send a support e-mail.
