### PR TITLE
Return Webhook Handled

### DIFF
--- a/src/Http/Controllers/Settings/Billing/StripeWebhookController.php
+++ b/src/Http/Controllers/Settings/Billing/StripeWebhookController.php
@@ -38,6 +38,8 @@ class StripeWebhookController extends WebhookController
         $this->sendInvoiceNotification(
             $user, $invoice
         );
+        
+        return new Response('Webhook Handled', 200);
     }
 
     /**
@@ -63,6 +65,8 @@ class StripeWebhookController extends WebhookController
         $this->sendInvoiceNotification(
             $team, $invoice
         );
+        
+        return new Response('Webhook Handled', 200);
     }
 
     /**


### PR DESCRIPTION
Return a 200 Webhook Handled response in the Stripe invoice.payment_succeeded webhook handlers.

Fixes #127 
