### PR TITLE
Fix Settings Tab Corners

### DIFF
--- a/resources/assets/less/elements/panels.less
+++ b/resources/assets/less/elements/panels.less
@@ -1,3 +1,7 @@
+.panel {
+    overflow: hidden;
+}
+
 .panel-heading {
     font-size: 15px;
     font-weight: 400;


### PR DESCRIPTION
A fix for the choppy corners of the settings navigation tabs. By adding "overflow: hidden" to ".panel" it preserves the smoothness of the "border-radius".
