### PR TITLE
remvoe name attributes from form inputs

### DIFF
--- a/resources/views/settings/payment-method/update-payment-method-stripe.blade.php
+++ b/resources/views/settings/payment-method/update-payment-method-stripe.blade.php
@@ -43,7 +43,7 @@
                     <label for="name" class="col-md-4 control-label">Cardholder's Name</label>
 
                     <div class="col-md-6">
-                        <input type="text" class="form-control" name="name" v-model="cardForm.name">
+                        <input type="text" class="form-control" v-model="cardForm.name">
                     </div>
                 </div>
 
@@ -54,7 +54,6 @@
                     <div class="col-md-6">
                         <input type="text"
                             class="form-control"
-                            name="number"
                             data-stripe="number"
                             :placeholder="placeholder"
                             v-model="cardForm.number">
@@ -70,7 +69,7 @@
                     <label for="cvc" class="col-md-4 control-label">Security Code</label>
 
                     <div class="col-md-6">
-                        <input type="text" class="form-control" name="cvc" data-stripe="cvc" v-model="cardForm.cvc">
+                        <input type="text" class="form-control" data-stripe="cvc" v-model="cardForm.cvc">
                     </div>
                 </div>
 
@@ -80,13 +79,13 @@
 
                     <!-- Month -->
                     <div class="col-md-3">
-                        <input type="text" class="form-control" name="month"
+                        <input type="text" class="form-control"
                             placeholder="MM" maxlength="2" data-stripe="exp-month" v-model="cardForm.month">
                     </div>
 
                     <!-- Year -->
                     <div class="col-md-3">
-                        <input type="text" class="form-control" name="year"
+                        <input type="text" class="form-control"
                             placeholder="YYYY" maxlength="4" data-stripe="exp-year" v-model="cardForm.year">
                     </div>
                 </div>
@@ -96,7 +95,7 @@
                     <label for="zip" class="col-md-4 control-label">ZIP / Postal Code</label>
 
                     <div class="col-md-6">
-                        <input type="text" class="form-control" name="zip" v-model="form.zip">
+                        <input type="text" class="form-control" v-model="form.zip">
                     </div>
                 </div>
 


### PR DESCRIPTION
removing the name attributes from all form elements.

as pre Stripe's documentation

`By omitting a name, the user-supplied data in those fields won’t be passed to your server when the form is submitted.`

[Stripe's Documentation](https://stripe.com/docs/custom-form)
