### PR TITLE
Minor fix to formattedDiscountDuration function

### DIFF
--- a/resources/assets/js/mixins/discounts.js
+++ b/resources/assets/js/mixins/discounts.js
@@ -82,7 +82,7 @@ module.exports = {
 
             switch (discount.duration) {
                 case 'forever':
-                    return 'for all future invoices';
+                    return 'all future invoices';
                 case 'once':
                     return 'a single invoice';
                 case 'repeating':


### PR DESCRIPTION
The removed string section caused a small display problem when a coupon with a duration of 'forever' was applied.
ex.: 'You currently receive a discount of $10.00 for for all future invoices.'
