### PR TITLE
Enable swapping configureTeamForNewUser Method

### DIFF
--- a/src/Interactions/Auth/Register.php
+++ b/src/Interactions/Auth/Register.php
@@ -35,7 +35,7 @@ class Register implements Contract
         $user = Spark::interact(CreateUserContract::class, [$request]);
 
         if (Spark::usesTeams()) {
-            $this->configureTeamForNewUser($request, $user);
+            Spark::interact(self::class.'@configureTeamForNewUser', [$request, $user]);
         }
 
         return $user;


### PR DESCRIPTION
The previous '$this->' style method was not swappable because it didn't go through the interact logic.
