### PR TITLE
fix moment locales

### DIFF
--- a/resources/assets/js/filters.js
+++ b/resources/assets/js/filters.js
@@ -18,23 +18,5 @@ Vue.filter('datetime', value => {
  * Format the given date into a relative time.
  */
 Vue.filter('relative', value => {
-    moment.updateLocale('en', {
-        relativeTime : {
-            future: "in %s",
-            past:   "%s",
-            s:  "1s",
-            m:  "1m",
-            mm: "%dm",
-            h:  "1h",
-            hh: "%dh",
-            d:  "1d",
-            dd: "%dd",
-            M:  "1 month ago",
-            MM: "%d months ago",
-            y:  "1y",
-            yy: "%dy"
-        }
-    });
-
-    return moment.utc(value).local().fromNow();
+    return moment.utc(value).local().locale('en-short').fromNow();
 });

--- a/resources/assets/js/spark-bootstrap.js
+++ b/resources/assets/js/spark-bootstrap.js
@@ -8,6 +8,29 @@ window.Promise = require('promise');
 window.Cookies = require('js-cookie');
 
 /*
+ * Define Moment locales
+ */
+window.moment.defineLocale('en-short', {
+    parentLocale: 'en',
+    relativeTime : {
+        future: "in %s",
+        past:   "%s",
+        s:  "1s",
+        m:  "1m",
+        mm: "%dm",
+        h:  "1h",
+        hh: "%dh",
+        d:  "1d",
+        dd: "%dd",
+        M:  "1 month ago",
+        MM: "%d months ago",
+        y:  "1y",
+        yy: "%dy"
+    }
+});
+window.moment.locale('en');
+
+/*
  * Load jQuery and Bootstrap jQuery, used for front-end interaction.
  */
 if (window.$ === undefined || window.jQuery === undefined) {


### PR DESCRIPTION
I tried to use moment to display nice date diffs with `fromNow()` method but it used the short format you intented only for the notifications modal. So, instead of changing the locale globally I defined a new locale `en-short` and used that for the `relative` filter.
