### PR TITLE
Remove remember merge from request on login

### DIFF
--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -54,6 +54,10 @@ class LoginController extends Controller
             $request->session()->put('spark:auth-remember', $request->remember);
         }
 
+        if (Spark::usesTwoFactorAuth() && \App\User::where('email', $request->email)->first()->uses_two_factor_auth) {
+            $request->merge(['remember' => '']);
+        }
+
         return $this->traitLogin($request);
     }
 

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -52,8 +52,6 @@ class LoginController extends Controller
     {
         if ($request->has('remember')) {
             $request->session()->put('spark:auth-remember', $request->remember);
-
-            $request->merge(['remember' => '']);
         }
 
         return $this->traitLogin($request);


### PR DESCRIPTION
Removed the merge on the request when making a login attempt, this resets the remember value which was stopping the remember me cookie from being created.

Fixes: #161
