### PR TITLE
Fixes a FatalThrowableError

### DIFF
--- a/src/Http/Controllers/Settings/Billing/StripeWebhookController.php
+++ b/src/Http/Controllers/Settings/Billing/StripeWebhookController.php
@@ -110,6 +110,9 @@ class StripeWebhookController extends WebhookController
             })->each(function ($subscription) {
                 $subscription->markAsCancelled();
             });
+        } else {
+            // No team found
+            return new Response('Webhook Handled', 200);
         }
 
         event(new TeamSubscriptionCancelled($team));


### PR DESCRIPTION
In the case where a user was deleted from the system and the Stripe web hook later tries to cancel their subscription, the web hook doesn't find the user so it defaults to attempting to cancel the team and incorrectly assumes that a team exists. I'm not using teams, and this results in the following exception:

```
Symfony\Component\Debug\Exception\FatalThrowableError: Fatal error: Call to a member function forceFill() on null in /Users/tommytompkins/eclipse-projects/ucpics/spark/src/Listeners/Teams/Subscription/UpdateActiveSubscription.php:20
```

This fix prevents the `TeamSubscriptionCancelled` event from being dispatched when no team was found.
