### PR TITLE
Cast owner_id in Team model to integer

### DIFF
--- a/src/Team.php
+++ b/src/Team.php
@@ -48,6 +48,7 @@ class Team extends Model
      * @var array
      */
     protected $casts = [
+        'owner_id' => 'integer',
         'trial_ends_at' => 'date',
     ];
 


### PR DESCRIPTION
Without this cast the button for a team owner to remove members doesn't show up.
The problem was that there is a strict compare in the [javascript code](https://github.com/laravel/spark/blob/1.0/resources/assets/js/settings/teams/team-members.js#L103). Without the cast it compares an integer with a string which always fails.
