### PR TITLE
Fixed 'action_url' for announcement update form.

### DIFF
--- a/resources/assets/js/kiosk/announcements.js
+++ b/resources/assets/js/kiosk/announcements.js
@@ -70,6 +70,7 @@ module.exports = {
             this.updateForm.icon = announcement.icon;
             this.updateForm.body = announcement.body;
             this.updateForm.action_text = announcement.action_text;
+            this.updateForm.action_url = announcement.action_url;
 
             $('#modal-update-announcement').modal('show');
         },


### PR DESCRIPTION
Adds the missing line for updating an announcement in the js.
