### PR TITLE
Added a guard that ensures that if there is a user then it should own…

### DIFF
--- a/src/Http/Requests/Settings/Teams/Subscription/CreateSubscriptionRequest.php
+++ b/src/Http/Requests/Settings/Teams/Subscription/CreateSubscriptionRequest.php
@@ -18,7 +18,7 @@ class CreateSubscriptionRequest extends FormRequest
      */
     public function authorize()
     {
-        return $this->user()->ownsTeam($this->route('team'));
+        return $this->user() && $this->user()->ownsTeam($this->route('team'));
     }
 
     /**


### PR DESCRIPTION
… the team. This resolves the [OwnsTeam() on null issue when using barryvdh/laravel-ide-helper with the :meta command](https://github.com/barryvdh/laravel-ide-helper/issues/343)
