### PR TITLE
fix #194 Make sparkPlan return only active plan

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -41,7 +41,7 @@ trait Billable
     {
         $subscription = $this->subscription($subscription);
 
-        if ($subscription) {
+        if ($subscription && $subscription->valid()) {
             return $this->availablePlans()->first(function ($value) use ($subscription) {
                 return $value->id === $subscription->provider_plan;
             });


### PR DESCRIPTION
Will return the current plan only if:
- Active
- Cancelled but still in grace period

Before this change it was returning the last plan even if it was cancelled and the grace period is over.
