### PR TITLE
Exclude users on trial for a plan from generic trialing

### DIFF
--- a/src/Http/Controllers/Kiosk/PerformanceIndicatorsController.php
+++ b/src/Http/Controllers/Kiosk/PerformanceIndicatorsController.php
@@ -86,6 +86,8 @@ class PerformanceIndicatorsController extends Controller
      */
     public function trialUsers()
     {
-        return Spark::user()->where('trial_ends_at', '>=', Carbon::now())->count();
+        return Spark::user()->where('trial_ends_at', '>=', Carbon::now())
+            ->whereDoesntHave('subscriptions')
+            ->count();
     }
 }

--- a/src/Http/Controllers/Kiosk/PerformanceIndicatorsController.php
+++ b/src/Http/Controllers/Kiosk/PerformanceIndicatorsController.php
@@ -86,8 +86,9 @@ class PerformanceIndicatorsController extends Controller
      */
     public function trialUsers()
     {
-        return Spark::user()->where('trial_ends_at', '>=', Carbon::now())
-            ->whereDoesntHave('subscriptions')
-            ->count();
+        return Spark::user()
+                        ->where('trial_ends_at', '>=', Carbon::now())
+                        ->whereDoesntHave('subscriptions')
+                        ->count();
     }
 }


### PR DESCRIPTION
When there's no freeplan or generic trial days, if a user subscribed to a plan that has trial days the user record in the DB would still have `trial_ends_at` filled, so this query will count him as on generic trial.

However in the kiosk we sum generic trial users and users trialing on a plan, in that case the user will be counted twice. 

This PR excludes users with subscriptions from being counted as generic trialing.
