### PR TITLE
fix #245 by checking for only paid plans on subscription screen

### DIFF
--- a/resources/assets/js/mixins/plans.js
+++ b/resources/assets/js/mixins/plans.js
@@ -93,12 +93,28 @@ module.exports = {
             return this.monthlyPlans.length > 0 && this.yearlyPlans.length > 0;
         },
 
+        /**
+         * Determine if both monthly and yearly plans are available.
+         */
+        hasMonthlyAndYearlyPaidPlans() {
+            return _.where(this.paidPlans, {interval: 'monthly'}).length > 0 &&
+                   _.where(this.paidPlans, {interval: 'yearly'}).length > 0;
+        },
+
 
         /**
          * Determine if only yearly plans are available.
          */
         onlyHasYearlyPlans() {
             return this.monthlyPlans.length == 0 && this.yearlyPlans.length > 0;
+        },
+
+        /**
+         * Determine if both monthly and yearly plans are available.
+         */
+        onlyHasYearlyPaidPlans() {
+            return _.where(this.paidPlans, {interval: 'monthly'}).length == 0 &&
+                   _.where(this.paidPlans, {interval: 'yearly'}).length > 0;
         },
 
 

--- a/resources/assets/js/settings/subscription/subscribe-braintree.js
+++ b/resources/assets/js/settings/subscription/subscribe-braintree.js
@@ -33,7 +33,7 @@ module.exports = {
          // If only yearly subscription plans are available, we will select that interval so that we
          // can show the plans. Then we'll select the first available paid plan from the list and
          // start the form in a good default spot. The user may then select another plan later.
-        if (this.onlyHasYearlyPlans) {
+        if (this.onlyHasYearlyPaidPlans) {
             this.showYearlyPlans();
         }
 

--- a/resources/assets/js/settings/subscription/subscribe-stripe.js
+++ b/resources/assets/js/settings/subscription/subscribe-stripe.js
@@ -68,7 +68,7 @@ module.exports = {
          // If only yearly subscription plans are available, we will select that interval so that we
          // can show the plans. Then we'll select the first available paid plan from the list and
          // start the form in a good default spot. The user may then select another plan later.
-        if (this.onlyHasYearlyPlans) {
+        if (this.onlyHasYearlyPaidPlans) {
             this.showYearlyPlans();
         }
 

--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -6,7 +6,7 @@
 
         <!-- Interval Selector Button Group -->
         <div class="pull-right">
-            <div class="btn-group" v-if="hasMonthlyAndYearlyPlans">
+            <div class="btn-group" v-if="hasMonthlyAndYearlyPaidPlans">
                 <!-- Monthly Plans -->
                 <button type="button" class="btn btn-default"
                         @click="showMonthlyPlans"


### PR DESCRIPTION
Check here: https://github.com/laravel/spark/issues/245

If spark only has 1 yearly plan, no monthly plans and a free plan exists the frontend of the subscription screen still attempts to show and select monthly plans although we only have yearly plans.

The bugs is because we show only paid plans, but check for existence of all plans (paid/not paid).
