### PR TITLE
Bind the closure to the interaction context

### DIFF
--- a/src/Configuration/CallsInteractions.php
+++ b/src/Configuration/CallsInteractions.php
@@ -69,7 +69,11 @@ trait CallsInteractions
             return static::interact(static::$interactions[$interaction], $parameters);
         }
 
-        return call_user_func_array(static::$interactions[$interaction], $parameters);
+        list($class) = explode('@', $interaction);
+
+        $method = static::$interactions[$interaction]->bindTo(app($class));
+
+        return call_user_func_array($method, $parameters);
     }
 
     /**


### PR DESCRIPTION
In this example:

```
    Spark::swap(SendInvitation::class.'@emailInvitation', function ($invitation) {
        Mail::send($this->view($invitation), ....);
    });
```

This PR will switch the closure to have the same context as the original method, in the current version some methods are impossible to swap like the `Subscribe` interaction where the handle method calls `$this->token`.
