### PR TITLE
Fix plans on mobile

### DIFF
--- a/resources/assets/less/elements/panels.less
+++ b/resources/assets/less/elements/panels.less
@@ -1,13 +1,8 @@
 .panel-default {
-    border-color: @brand-primary;
-    .panel-heading {
-        background: @brand-primary;
-        color: #ffffff;
-    }
     .panel-footer {
-        background: @brand-primary;
+        background: #f5f5f5;
         &:hover {
-            background: darken(@brand-primary, 15%);
+            background: darken(#f5f5f5, 15%);
         }
     }
 }

--- a/resources/assets/less/elements/panels.less
+++ b/resources/assets/less/elements/panels.less
@@ -1,3 +1,62 @@
+.panel-default {
+    border-color: @brand-primary;
+    .panel-heading {
+        background: @brand-primary;
+        color: #ffffff;
+    }
+    .panel-footer {
+        background: @brand-primary;
+        &:hover {
+            background: darken(@brand-primary, 15%);
+        }
+    }
+}
+
+.panel-primary {
+    .panel-footer {
+        background: #337ab7;
+        &:hover {
+            background: darken(@brand-primary, 15%);
+        }
+    }
+}
+
+.panel-success {
+    .panel-footer {
+        background: #5cb85c;
+        &:hover {
+            background: darken(@brand-success, 15%);
+        }
+    }
+}
+
+.panel-info {
+    .panel-footer {
+        background: #5bc0de;
+        &:hover {
+            background: darken(@brand-info, 15%);
+        }
+    }
+}
+
+.panel-warning {
+    .panel-footer {
+        background: #f0ad4e;
+        &:hover {
+            background: darken(@brand-warning, 15%);
+        }
+    }
+}
+
+.panel-danger {
+    .panel-footer {
+        background: #d9534f;
+        &:hover {
+            background: darken(@brand-danger, 15%);
+        }
+    }
+}
+
 .panel {
     overflow: hidden;
 }
@@ -15,4 +74,36 @@
 	.panel-body, .panel-header {
 		padding: 0;
 	}
+}
+
+button.panel-footer,
+a.panel-footer {
+    color: white;
+    text-align: center;
+    text-transform: uppercase;
+    text-decoration: none;
+    width: 100%;
+    display:block;
+
+    margin-bottom: 0;
+    font-weight: 300;
+    vertical-align: middle;
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+    cursor: pointer;
+    background-image: none;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.6;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
+    &:focus {
+        outline-color: transparent;
+        outline-style: none;
+    }
 }

--- a/resources/views/settings/subscription/resume-subscription.blade.php
+++ b/resources/views/settings/subscription/resume-subscription.blade.php
@@ -56,48 +56,62 @@
                 </p>
             @endif
 
-            <table class="table table-borderless m-b-none">
-                <thead></thead>
-                <tbody>
-                    <tr v-for="plan in paidPlansForActiveInterval">
-                        <!-- Plan Name -->
-                        <td>
-                            <div class="btn-table-align" @click="showPlanDetails(plan)">
-                                <span style="cursor: pointer;">
-                                    <strong>@{{ plan.name }}</strong>
-                                </span>
+            <div class="row">
+                <div v-for="plan in plansForActiveInterval">
+
+                    <div class="col-xs-10 col-sm-6 col-xs-offset-1 col-sm-offset-0 ">
+
+                        <div class="panel" :class="{'panel-default' : ! isActivePlan(plan), 'panel-success' : isActivePlan(plan)}">
+                            <div class="panel-body">
+                                <div class="text-center">
+                                    <h4 class="text-uppercase">
+                                        <strong>@{{ plan.name }}</strong>
+                                    </h4>
+                                </div>
+
+                                <ul>
+                                    <li v-for="feature in plan.features">
+                                        @{{ feature }}
+                                    </li>
+                                </ul>
+
+                                <div class="text-center">
+                                    <div v-if="plan.trialDays">
+                                        @{{ plan.trialDays}} Day Trial
+                                    </div>
+
+                                    <span class="text-muted" v-if="plan.price == 0">
+                                        Free
+                                    </span>
+
+                                    <span class="text-muted" v-else>
+                                        @{{ priceWithTax(plan) | currency spark.currencySymbol }} / @{{ plan.interval | capitalize }}
+                                    </span>
+                                </div>
                             </div>
-                        </td>
 
-                        <!-- Plan Features Button -->
-                        <td>
-                            <button class="btn btn-default m-l-sm" @click="showPlanDetails(plan)">
-                                <i class="fa fa-btn fa-star-o"></i>Plan Features
-                            </button>
-                        </td>
 
-                        <!-- Plan Price -->
-                        <td>
-                            <div class="btn-table-align">
-                                @{{ priceWithTax(plan) | currency spark.currencySymbol }} / @{{ plan.interval | capitalize }}
-                            </div>
-                        </td>
+                            <button class="panel-footer" @click="updateSubscription(plan)" :disabled="selectingPlan">
 
-                        <!-- Plan Select Button -->
-                        <td class="text-right">
-                            <button class="btn btn-warning btn-plan" @click="updateSubscription(plan)" :disabled="selectingPlan">
                                 <span v-if="selectingPlan === plan">
                                     <i class="fa fa-btn fa-spinner fa-spin"></i>Resuming
                                 </span>
 
-                                <span v-else>
+                                <span v-if="selectingPlan !== plan && isActivePlan(plan)">
                                     Resume
                                 </span>
+
+                                <span v-if="selectingPlan !== plan && !isActivePlan(plan)">
+                                    Change and resume
+                                </span>
                             </button>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
         </div>
     </div>
 </spark-resume-subscription>

--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -46,59 +46,54 @@
             @{{ form.errors.get('plan') }}
         </div>
 
-        <table class="table table-borderless m-b-none">
-            <thead></thead>
-            <tbody>
-                <tr v-for="plan in paidPlansForActiveInterval">
-                    <!-- Plan Name -->
-                    <td>
-                        <div class="btn-table-align" @click="showPlanDetails(plan)">
-                            <span style="cursor: pointer;">
-                                <strong>@{{ plan.name }}</strong>
+        <div class="row">
+            <div v-for="plan in paidPlansForActiveInterval">
+
+                <div class="col-xs-10 col-sm-6 col-xs-offset-1 col-sm-offset-0 ">
+
+                    <div class="panel" :class="{'panel-default' : selectedPlan !== plan, 'panel-success' : selectedPlan === plan}">
+                        <div class="panel-body">
+                            <div class="text-center">
+                                <h4 class="text-uppercase">
+                                    <strong>@{{ plan.name }}</strong>
+                                </h4>
+                            </div>
+
+                            <ul>
+                                <li v-for="feature in plan.features">
+                                    @{{ feature }}
+                                </li>
+                            </ul>
+
+                            <div class="text-center">
+                                <div v-if="plan.trialDays">
+                                    @{{ plan.trialDays}} Day Trial
+                                </div>
+
+                                <span class="text-muted" v-if="plan.price == 0">
+                                    Free
+                                </span>
+
+                                <span class="text-muted" v-else>
+                                    @{{ priceWithTax(plan) | currency spark.currencySymbol }} / @{{ plan.interval | capitalize }}
+                                </span>
+                            </div>
+                        </div>
+
+                        <button class="panel-footer"
+                        @click="selectPlan(plan)">
+                            <span v-if="selectedPlan === plan">
+                                <i class="fa fa-btn fa-check"></i> Selected
                             </span>
-                        </div>
-                    </td>
-
-                    <!-- Plan Features Button -->
-                    <td>
-                        <button class="btn btn-default m-l-sm" @click="showPlanDetails(plan)">
-                            <i class="fa fa-btn fa-star-o"></i>Plan Features
-                        </button>
-                    </td>
-
-                    <!-- Plan Price -->
-                    <td>
-                        <div class="btn-table-align">
-                            @{{ plan.price | currency spark.currencySymbol }} / @{{ plan.interval | capitalize }}
-                        </div>
-                    </td>
-
-                    <!-- Trial Days -->
-                    <td>
-                        <div class="btn-table-align" v-if="plan.trialDays">
-                            @{{ plan.trialDays}} Day Trial
-                        </div>
-                    </td>
-
-                    <!-- Plan Select Button -->
-                    <td class="text-right">
-                        <button class="btn btn-primary-outline btn-plan"
-                                v-if="selectedPlan !== plan"
-                                @click="selectPlan(plan)"
-                                :disabled="form.busy">
-
-                            Select
+                            <span v-if="selectedPlan !== plan">
+                                Select
+                            </span>
                         </button>
 
-                        <button class="btn btn-primary btn-plan"
-                                v-if="selectedPlan === plan"
-                                disabled>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-                            <i class="fa fa-btn fa-check"></i>Selected
-                        </button>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
     </div>
 </div>

--- a/resources/views/settings/subscription/update-subscription.blade.php
+++ b/resources/views/settings/subscription/update-subscription.blade.php
@@ -59,63 +59,57 @@
                 </p>
             @endif
 
-            <table class="table table-borderless m-b-none">
-                <thead></thead>
-                <tbody>
-                    <tr v-for="plan in plansForActiveInterval">
-                        <!-- Plan Name -->
-                        <td>
-                            <div class="btn-table-align" @click="showPlanDetails(plan)">
-                                <span style="cursor: pointer;">
-                                    <strong>@{{ plan.name }}</strong>
-                                </span>
+            <div class="row">
+                <div v-for="plan in plansForActiveInterval">
+
+                    <div class="col-xs-10 col-sm-6 col-xs-offset-1 col-sm-offset-0 ">
+
+                        <div class="panel" :class="{'panel-default' : ! isActivePlan(plan), 'panel-success' : isActivePlan(plan)}">
+                            <div class="panel-body">
+                                <div class="text-center">
+                                    <h4 class="text-uppercase">
+                                        <strong>@{{ plan.name }}</strong>
+                                    </h4>
+                                </div>
+
+                                <ul>
+                                    <li v-for="feature in plan.features">
+                                        @{{ feature }}
+                                    </li>
+                                </ul>
+
+                                <div class="text-center">
+                                    <div v-if="plan.trialDays">
+                                        @{{ plan.trialDays}} Day Trial
+                                    </div>
+
+                                    <span class="text-muted" v-if="plan.price == 0">
+                                        Free
+                                    </span>
+
+                                    <span class="text-muted" v-else>
+                                        @{{ priceWithTax(plan) | currency spark.currencySymbol }} / @{{ plan.interval | capitalize }}
+                                    </span>
+                                </div>
                             </div>
-                        </td>
 
-                        <!-- Plan Features Button -->
-                        <td>
-                            <button class="btn btn-default m-l-sm" @click="showPlanDetails(plan)">
-                                <i class="fa fa-btn fa-star-o"></i>Plan Features
-                            </button>
-                        </td>
-
-                        <!-- Plan Price -->
-                        <td>
-                            <div class="btn-table-align">
-                                <span v-if="plan.price == 0">
-                                    Free
-                                </span>
-
-                                <span v-else>
-                                    @{{ priceWithTax(plan) | currency spark.currencySymbol }} / @{{ plan.interval | capitalize }}
-                                </span>
-                            </div>
-                        </td>
-
-                        <!-- Plan Select Button -->
-                        <td class="text-right">
-                            <button class="btn btn-primary btn-plan" v-if="isActivePlan(plan)" disabled>
-                                <i class="fa fa-btn fa-check"></i>Current Plan
+                            <button class="panel-footer" v-if="isActivePlan(plan)" disabled>
+                                <i class="fa fa-btn fa-check"></i> Current Plan
                             </button>
 
-                            <button class="btn btn-primary-outline btn-plan"
-                                    v-if=" ! isActivePlan(plan) && selectingPlan !== plan"
-                                    @click="confirmPlanUpdate(plan)"
-                                    :disabled="selectingPlan">
-
-                                Select
+                            <button class="panel-footer" v-if="!isActivePlan(plan) && selectingPlan !== plan" @click="confirmPlanUpdate(plan)" :disabled="selectingPlan">
+                                Change Plan
                             </button>
 
-                            <button class="btn btn-primary btn-plan"
-                                    v-if="selectingPlan && selectingPlan === plan"
-                                    disabled>
-
-                                <i class="fa fa-btn fa-spinner fa-spin"></i>Updating
+                            <button class="panel-footer" v-if="selectingPlan && selectingPlan === plan">
+                                <i class="fa fa-btn fa-spinner fa-spin"></i> Updating
                             </button>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
         </div>
     </div>
 


### PR DESCRIPTION
This Pull change the plans from using tables to using the bootstrap grid, in doing so the styling is changed to a card style.

This pull request also changes the resume plan text to 'Resume' if you were previously on the plan, or 'Change and Resume' if you were not previously on the plan, but are resuming a subscription.

Fixes #202 and #255.
