### PR TITLE
UX Enhancements

### DIFF
--- a/resources/assets/js/settings/subscription/subscribe-braintree.js
+++ b/resources/assets/js/settings/subscription/subscribe-braintree.js
@@ -37,8 +37,6 @@ module.exports = {
             this.showYearlyPlans();
         }
 
-        this.selectPlan(this.paidPlansForActiveInterval[0]);
-
          // Next, we will configure the braintree container element on the page and handle the nonce
          // received callback. We'll then set the nonce and fire off the subscribe method so this
          // nonce can be used to create the subscription for the billable entity being managed.

--- a/resources/assets/js/settings/subscription/subscribe-stripe.js
+++ b/resources/assets/js/settings/subscription/subscribe-stripe.js
@@ -71,10 +71,6 @@ module.exports = {
         if (this.onlyHasYearlyPaidPlans) {
             this.showYearlyPlans();
         }
-
-        this.selectPlan(
-            this.paidPlansForActiveInterval[0]
-        );
     },
 
 

--- a/resources/views/settings/subscription/resume-subscription.blade.php
+++ b/resources/views/settings/subscription/resume-subscription.blade.php
@@ -31,7 +31,7 @@
             <div class="clearfix"></div>
         </div>
 
-        <div class="panel-body">
+        <div class="panel-body table-responsive">
             <!-- Plan Error Message - In General Will Never Be Shown -->
             <div class="alert alert-danger" v-if="planForm.errors.has('plan')">
                 @{{ planForm.errors.get('plan') }}
@@ -85,12 +85,20 @@
 
                         <!-- Plan Select Button -->
                         <td class="text-right">
-                            <button class="btn btn-warning btn-plan" @click="updateSubscription(plan)" :disabled="selectingPlan">
+                            <button class="btn btn-plan"
+                                    v-bind:class="{'btn-warning-outline': ! isActivePlan(plan), 'btn-warning': isActivePlan(plan)}"
+                                    @click="updateSubscription(plan)"
+                                    :disabled="selectingPlan">
+
                                 <span v-if="selectingPlan === plan">
                                     <i class="fa fa-btn fa-spinner fa-spin"></i>Resuming
                                 </span>
 
-                                <span v-else>
+                                <span v-if="! isActivePlan(plan) && selectingPlan !== plan">
+                                    Switch
+                                </span>
+
+                                <span v-if="isActivePlan(plan) && selectingPlan !== plan">
                                     Resume
                                 </span>
                             </button>

--- a/resources/views/settings/subscription/subscribe-braintree.blade.php
+++ b/resources/views/settings/subscription/subscribe-braintree.blade.php
@@ -5,7 +5,7 @@
     @include('spark::settings.subscription.subscribe-common')
 
     <!-- Billing Information -->
-    <div class="panel panel-default">
+    <div class="panel panel-default" v-show="selectedPlan">
         <div class="panel-heading"><i class="fa fa-btn fa-credit-card"></i>Billing Information</div>
 
         <div class="panel-body">

--- a/resources/views/settings/subscription/subscribe-stripe.blade.php
+++ b/resources/views/settings/subscription/subscribe-stripe.blade.php
@@ -5,7 +5,7 @@
     @include('spark::settings.subscription.subscribe-common')
 
     <!-- Billing Information -->
-    <div class="panel panel-default">
+    <div class="panel panel-default" v-show="selectedPlan">
         <div class="panel-heading">Billing Information</div>
 
         <div class="panel-body">

--- a/resources/views/settings/subscription/update-subscription.blade.php
+++ b/resources/views/settings/subscription/update-subscription.blade.php
@@ -103,7 +103,7 @@
                                     @click="confirmPlanUpdate(plan)"
                                     :disabled="selectingPlan">
 
-                                Select
+                                Switch
                             </button>
 
                             <button class="btn btn-primary btn-plan"


### PR DESCRIPTION
- Use `table-responsive` class in resume subscription screen.
- Changed the text of the buttons to "Switch" in the Update Subscription & Resume Subscription screens.
- In the subscription screen the billing panel will be hidden and no plans selected initially, once the user selects a plan the billing panel will appear. This will eliminate the confusion about the "selected" button while the user is not subscribed to any plan.

<img width="778" alt="screen shot 2016-09-14 at 7 43 20 pm" src="https://cloud.githubusercontent.com/assets/4332182/18523294/f0758788-7ab3-11e6-8662-c9ebc706d52f.png">
<img width="771" alt="screen shot 2016-09-14 at 7 45 35 pm" src="https://cloud.githubusercontent.com/assets/4332182/18523295/f07a20ae-7ab3-11e6-875e-d31e56b0ded7.png">
<img width="803" alt="screen shot 2016-09-14 at 7 45 57 pm" src="https://cloud.githubusercontent.com/assets/4332182/18523296/f0836d12-7ab3-11e6-861c-5054eda2fcff.png">
