### PR TITLE
Fix unread announcements issue

### DIFF
--- a/resources/assets/js/spark.js
+++ b/resources/assets/js/spark.js
@@ -247,7 +247,7 @@ module.exports = {
          */
         hasUnreadAnnouncements() {
             if (this.notifications && this.user) {
-                if (! this.user.last_read_announcements_at) {
+                if (this.notifications.announcements.length && ! this.user.last_read_announcements_at) {
                     return true;
                 }
 


### PR DESCRIPTION
The red dot indicating unread announcements was showing up if there are notifications and the `last_read_announcements_at` is NULL, this fix will show it only if there are announcements in the DB.
