### PR TITLE
Throw 404 if coupon not found

### DIFF
--- a/src/Http/Controllers/CouponController.php
+++ b/src/Http/Controllers/CouponController.php
@@ -57,5 +57,7 @@ class CouponController extends Controller
         if ($coupon = $this->coupons->forBillable($user)) {
             return response()->json($coupon->toArray());
         }
+
+        abort(404);
     }
 }

--- a/src/Http/Controllers/TeamCouponController.php
+++ b/src/Http/Controllers/TeamCouponController.php
@@ -42,5 +42,7 @@ class TeamCouponController extends Controller
         if ($coupon = $this->coupons->forBillable($team)) {
             return response()->json($coupon->toArray());
         }
+
+        abort(404);
     }
 }


### PR DESCRIPTION
This will prevent filling `this.currentDiscount` with unpredictable data if no coupon was found.
