### PR TITLE
Mark dev-master as 3.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Marking dev-master as 3.0-dev to be able to install 2.0 as 2.0-dev

Currently `2.0-dev` / `~2.0@dev` install dev-master, not 2.0.
