### PR TITLE
Disable creating teams from dashboard

### DIFF
--- a/resources/views/nav/teams.blade.php
+++ b/resources/views/nav/teams.blade.php
@@ -4,11 +4,13 @@
 <li class="dropdown-header">Teams</li>
 
 <!-- Create Team -->
-<li>
-    <a href="/settings#/teams">
-        <i class="fa fa-fw fa-btn fa-plus"></i>Create Team
-    </a>
-</li>
+@if(Spark::createsTeamsFromDashboard())
+    <li>
+        <a href="/settings#/teams">
+            <i class="fa fa-fw fa-btn fa-plus"></i>Create Team
+        </a>
+    </li>
+@endif
 
 <!-- Switch Current Team -->
 <li v-for="team in teams">

--- a/resources/views/settings/teams.blade.php
+++ b/resources/views/settings/teams.blade.php
@@ -1,7 +1,9 @@
 <spark-teams :user="user" :teams="teams" inline-template>
     <div>
         <!-- Create Team -->
-        @include('spark::settings.teams.create-team')
+        @if(Spark::createsTeamsFromDashboard())
+            @include('spark::settings.teams.create-team')
+        @endif
 
         <!-- Pending Invitations -->
         @include('spark::settings.teams.pending-invitations')

--- a/src/Configuration/ManagesModelOptions.php
+++ b/src/Configuration/ManagesModelOptions.php
@@ -114,7 +114,7 @@ trait ManagesModelOptions
      *
      * @return void
      */
-    public static function doesntCreateTeamsFromDashboard()
+    public static function dontCreateTeamsFromDashboard()
     {
         static::$createsTeamsFromDashboard = false;
     }

--- a/src/Configuration/ManagesModelOptions.php
+++ b/src/Configuration/ManagesModelOptions.php
@@ -21,6 +21,13 @@ trait ManagesModelOptions
     public static $teamModel = 'App\Team';
 
     /**
+     * Indicates that users can create teams from the dashboard.
+     *
+     * @var bool
+     */
+    public static $createsTeamsFromDashboard = true;
+
+    /**
      * Set the user model class name.
      *
      * @param  string  $userModel
@@ -90,5 +97,25 @@ trait ManagesModelOptions
     public static function team()
     {
         return new static::$teamModel;
+    }
+
+    /**
+     * Determines if users can create teams from dashboard.
+     *
+     * @return bool
+     */
+    public static function createsTeamsFromDashboard()
+    {
+        return static::$createsTeamsFromDashboard;
+    }
+
+    /**
+     * Specifies that users cannot create teams from dashboard.
+     *
+     * @return void
+     */
+    public static function doesntCreateTeamsFromDashboard()
+    {
+        static::$createsTeamsFromDashboard = false;
     }
 }

--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -33,6 +33,7 @@ trait ProvidesScriptVariables
             'usesApi' => Spark::usesApi(),
             'usesBraintree' => Spark::billsUsingBraintree(),
             'usesTeams' => Spark::usesTeams(),
+            'createsTeamsFromDashboard' => Spark::createsTeamsFromDashboard(),
             'usesStripe' => Spark::billsUsingStripe(),
         ];
     }

--- a/src/Http/Controllers/Settings/Teams/TeamController.php
+++ b/src/Http/Controllers/Settings/Teams/TeamController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Spark\Http\Controllers\Settings\Teams;
 
+use Laravel\Spark\Spark;
 use Illuminate\Http\Request;
 use Laravel\Spark\Events\Teams\TeamDeleted;
 use Laravel\Spark\Events\Teams\DeletingTeam;
@@ -28,6 +29,10 @@ class TeamController extends Controller
      */
     public function store(Request $request)
     {
+        if (! Spark::createsTeamsFromDashboard()) {
+            abort(404);
+        }
+
         $this->interaction($request, CreateTeam::class, [
             $request->user(), $request->all()
         ]);


### PR DESCRIPTION
Based on feedback from @spaceageliving at https://github.com/laravel/spark/issues/231

This PR adds the following option:

```
Spark::dontCreateTeamsFromDashboard();
```

When used, it'll disable creating teams from the dashboard completely, means that the user will create only a single team on signup and won't be able to create any more teams.

It hides the "Create team" link from the navigation menu as well as the "Create team" panel from the teams view.
