### PR TITLE
Fixes ownedTeams count query

### DIFF
--- a/src/Interactions/Settings/Teams/CreateTeam.php
+++ b/src/Interactions/Settings/Teams/CreateTeam.php
@@ -44,7 +44,7 @@ class CreateTeam implements Contract
             return;
         }
 
-        if ($plan->teams <= $user->ownedTeams()->count()) {
+        if ($plan->teams <= $user->ownedTeams->count()) {
             $validator->errors()->add('name', 'Please upgrade your subscription to create more teams.');
         }
     }


### PR DESCRIPTION
Fixes the ownedTeams count in CreateTeam throwing an SQL error when using maxTeams on a user plan.
