### PR TITLE
Fix trialing users count

### DIFF
--- a/resources/assets/js/kiosk/metrics.js
+++ b/resources/assets/js/kiosk/metrics.js
@@ -66,7 +66,7 @@ module.exports = {
         getTrialUsers() {
             this.$http.get('/spark/kiosk/performance-indicators/trialing')
                 .then(response => {
-                    this.genericTrialUsers = response.data;
+                    this.genericTrialUsers = parseInt(response.data);
                 });
         },
 


### PR DESCRIPTION
`/spark/kiosk/performance-indicators/trialing` returns a count, but is interpreted as text.

In my test situation this count gives me a strange result: 

```
return this.genericTrialUsers + _.reduce(this.plans, (memo, plan) => {
     return memo + plan.trialing;
 }, 0);
```

-->
`1 + 0 = 10`
`0 + 0 = 00`

The problem is that `this.genericTrialUsers` is text and not an integer. 

---

Alternatively `/spark/kiosk/performance-indicators/trialing` could return a JSON response. 
