### PR TITLE
fix issue with calling swapped interactions

### DIFF
--- a/src/Configuration/CallsInteractions.php
+++ b/src/Configuration/CallsInteractions.php
@@ -44,13 +44,13 @@ trait CallsInteractions
         list($class, $method) = explode('@', $interaction);
 
         if (isset(static::$interactions[$interaction])) {
-            return static::callSwappedInteraction($interaction, $parameters);
+            return static::callSwappedInteraction($interaction, $parameters, $class);
         }
 
         $base = class_basename($class);
 
         if (isset(static::$interactions[$base.'@'.$method])) {
-            return static::callSwappedInteraction($base.'@'.$method, $parameters);
+            return static::callSwappedInteraction($base.'@'.$method, $parameters, $class);
         }
 
         return call_user_func_array([app($class), $method], $parameters);
@@ -63,13 +63,11 @@ trait CallsInteractions
      * @param  array  $parameters
      * @return mixed
      */
-    protected static function callSwappedInteraction($interaction, array $parameters)
+    protected static function callSwappedInteraction($interaction, array $parameters, $class)
     {
         if (is_string(static::$interactions[$interaction])) {
             return static::interact(static::$interactions[$interaction], $parameters);
         }
-
-        list($class) = explode('@', $interaction);
 
         $method = static::$interactions[$interaction]->bindTo(app($class));
 


### PR DESCRIPTION
Since now we need to be able to create an instance of the interaction class to bind the closure context to, we need to pass the full class name of the interaction.
