### PR TITLE
Customize "Team" name

### DIFF
--- a/install-stubs/resources/lang/en/validation.php
+++ b/install-stubs/resources/lang/en/validation.php
@@ -111,6 +111,8 @@ return [
     |
     */
 
-    'attributes' => [],
+    'attributes' => [
+        'team' => Spark::teamString()
+    ],
 
 ];

--- a/resources/assets/js/mixins/discounts.js
+++ b/resources/assets/js/mixins/discounts.js
@@ -36,7 +36,7 @@ module.exports = {
 
             this.loadingCurrentDiscount = true;
 
-            this.$http.get(`/coupon/team/${team.id}`)
+            this.$http.get(`/coupon/${Spark.teamString}/${team.id}`)
                 .then(response => {
                     this.currentDiscount = response.data;
 

--- a/resources/assets/js/mixins/subscriptions.js
+++ b/resources/assets/js/mixins/subscriptions.js
@@ -169,7 +169,7 @@ module.exports = {
         urlForPlanUpdate() {
             return this.billingUser
                             ? '/settings/subscription'
-                            : `/settings/teams/${this.team.id}/subscription`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/subscription`;
         }
     }
 };

--- a/resources/assets/js/settings/invoices.js
+++ b/resources/assets/js/settings/invoices.js
@@ -41,7 +41,7 @@ module.exports = {
 		urlForInvoices() {
 			return this.billingUser
 							? '/settings/invoices'
-							: `/settings/teams/${this.team.id}/invoices`;
+							: `/settings/${Spark.teamStringPlural}/${this.team.id}/invoices`;
 		}
 	}
 };

--- a/resources/assets/js/settings/invoices/invoice-list.js
+++ b/resources/assets/js/settings/invoices/invoice-list.js
@@ -9,7 +9,7 @@ module.exports = {
         downloadUrlFor(invoice) {
             return this.billingUser
                         ? `/settings/invoice/${invoice.id}`
-                        : `/settings/teams/${this.team.id}/invoice/${invoice.id}`;
+                        : `/settings/${Spark.teamStringPlural}/${this.team.id}/invoice/${invoice.id}`;
         }
     }
 };

--- a/resources/assets/js/settings/invoices/update-extra-billing-information.js
+++ b/resources/assets/js/settings/invoices/update-extra-billing-information.js
@@ -39,7 +39,7 @@ module.exports = {
         urlForUpdate() {
             return this.billingUser
                             ? '/settings/extra-billing-information'
-                            : `/settings/teams/${this.team.id}/extra-billing-information`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/extra-billing-information`;
         }
     }
 };

--- a/resources/assets/js/settings/payment-method/redeem-coupon.js
+++ b/resources/assets/js/settings/payment-method/redeem-coupon.js
@@ -35,7 +35,7 @@ module.exports = {
         urlForRedemption() {
             return this.billingUser
                             ? '/settings/payment-method/coupon'
-                            : `/settings/teams/${this.team.id}/payment-method/coupon`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/payment-method/coupon`;
         }
     }
 };

--- a/resources/assets/js/settings/payment-method/update-payment-method-braintree.js
+++ b/resources/assets/js/settings/payment-method/update-payment-method-braintree.js
@@ -71,7 +71,7 @@ module.exports = {
         urlForUpdate() {
             return this.billingUser
                             ? '/settings/payment-method'
-                            : `/settings/teams/${this.team.id}/payment-method`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/payment-method`;
         },
 
 

--- a/resources/assets/js/settings/payment-method/update-payment-method-stripe.js
+++ b/resources/assets/js/settings/payment-method/update-payment-method-stripe.js
@@ -138,7 +138,7 @@ module.exports = {
         urlForUpdate() {
             return this.billingUser
                             ? '/settings/payment-method'
-                            : `/settings/teams/${this.team.id}/payment-method`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/payment-method`;
         },
 
 

--- a/resources/assets/js/settings/payment-method/update-vat-id.js
+++ b/resources/assets/js/settings/payment-method/update-vat-id.js
@@ -36,7 +36,7 @@ module.exports = {
         urlForUpdate() {
             return this.billingUser
                             ? '/settings/payment-method/vat-id'
-                            : `/settings/teams/${this.team.id}/payment-method/vat-id`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/payment-method/vat-id`;
         }
     }
 }

--- a/resources/assets/js/settings/subscription.js
+++ b/resources/assets/js/settings/subscription.js
@@ -56,7 +56,7 @@ module.exports = {
          * Get the URL for retrieving the application's plans.
          */
         urlForPlans() {
-            return this.billingUser ? '/spark/plans' : '/spark/team-plans';
+            return this.billingUser ? '/spark/plans' : `/spark/${Spark.teamString}-plans`;
         }
     }
 };

--- a/resources/assets/js/settings/subscription/cancel-subscription.js
+++ b/resources/assets/js/settings/subscription/cancel-subscription.js
@@ -42,7 +42,7 @@ module.exports = {
         urlForCancellation() {
             return this.billingUser
                             ? '/settings/subscription'
-                            : `/settings/teams/${this.team.id}/subscription`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/subscription`;
         }
     }
 };

--- a/resources/assets/js/settings/subscription/subscribe-braintree.js
+++ b/resources/assets/js/settings/subscription/subscribe-braintree.js
@@ -90,7 +90,7 @@ module.exports = {
         urlForNewSubscription() {
             return this.billingUser
                             ? '/settings/subscription'
-                            : `/settings/teams/${this.team.id}/subscription`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/subscription`;
         }
     }
 };

--- a/resources/assets/js/settings/subscription/subscribe-stripe.js
+++ b/resources/assets/js/settings/subscription/subscribe-stripe.js
@@ -189,7 +189,7 @@ module.exports = {
         urlForNewSubscription() {
             return this.billingUser
                             ? '/settings/subscription'
-                            : `/settings/teams/${this.team.id}/subscription`;
+                            : `/settings/${Spark.teamStringPlural}/${this.team.id}/subscription`;
         },
 
 

--- a/resources/assets/js/settings/teams/create-team.js
+++ b/resources/assets/js/settings/teams/create-team.js
@@ -16,7 +16,7 @@ module.exports = {
          * Handle the "activatedTab" event.
          */
         activatedTab(tab) {
-            if (tab === 'teams') {
+            if (tab === Spark.teamStringPlural) {
                 Vue.nextTick(() => {
                     $('#create-team-name').focus();
                 });
@@ -32,7 +32,7 @@ module.exports = {
          * Create a new team.
          */
         create() {
-            Spark.post('/settings/teams', this.form)
+            Spark.post('/settings/'+Spark.teamStringPlural, this.form)
                 .then(() => {
                     this.form.name = '';
 

--- a/resources/assets/js/settings/teams/current-teams.js
+++ b/resources/assets/js/settings/teams/current-teams.js
@@ -63,7 +63,7 @@ module.exports = {
          * Delete the given team.
          */
         deleteTeam() {
-            Spark.delete(`/settings/teams/${this.deletingTeam.id}`, this.deleteTeamForm)
+            Spark.delete(`/settings/${Spark.teamStringPlural}/${this.deletingTeam.id}`, this.deleteTeamForm)
                 .then(() => {
                     this.$dispatch('updateUser');
                     this.$dispatch('updateTeams');
@@ -79,7 +79,7 @@ module.exports = {
          * Get the URL for leaving a team.
          */
         urlForLeaving() {
-            return `/settings/teams/${this.leavingTeam.id}/members/${this.user.id}`;
+            return `/settings/${Spark.teamStringPlural}/${this.leavingTeam.id}/members/${this.user.id}`;
         }
     }
 };

--- a/resources/assets/js/settings/teams/send-invitation.js
+++ b/resources/assets/js/settings/teams/send-invitation.js
@@ -18,7 +18,7 @@ module.exports = {
          * Send a team invitation.
          */
         send() {
-            Spark.post(`/settings/teams/${this.team.id}/invitations`, this.form)
+            Spark.post(`/settings/${Spark.teamStringPlural}/${this.team.id}/invitations`, this.form)
                 .then(() => {
                     this.form.email = '';
 

--- a/resources/assets/js/settings/teams/team-members.js
+++ b/resources/assets/js/settings/teams/team-members.js
@@ -34,7 +34,7 @@ module.exports = {
          * Get the available team member roles.
          */
         getRoles() {
-            this.$http.get('/settings/teams/roles')
+            this.$http.get(`/settings/${Spark.teamStringPlural}/roles`)
                 .then(response => {
                     this.roles = response.data;
                 });
@@ -130,7 +130,7 @@ module.exports = {
          * Get the URL for updating a team member.
          */
         urlForUpdating: function () {
-            return `/settings/teams/${this.team.id}/members/${this.updatingTeamMember.id}`;
+            return `/settings/${Spark.teamStringPlural}/${this.team.id}/members/${this.updatingTeamMember.id}`;
         },
 
 
@@ -138,7 +138,7 @@ module.exports = {
          * Get the URL for deleting a team member.
          */
         urlForDeleting() {
-            return `/settings/teams/${this.team.id}/members/${this.deletingTeamMember.id}`;
+            return `/settings/${Spark.teamStringPlural}/${this.team.id}/members/${this.deletingTeamMember.id}`;
         }
     }
 };

--- a/resources/assets/js/settings/teams/team-membership.js
+++ b/resources/assets/js/settings/teams/team-membership.js
@@ -34,7 +34,7 @@ module.exports = {
          * Get all of the invitations for the team.
          */
         getInvitations() {
-            this.$http.get(`/settings/teams/${this.team.id}/invitations`)
+            this.$http.get(`/settings/${Spark.teamStringPlural}/${this.team.id}/invitations`)
                 .then(response => {
                     this.invitations = response.data;
                 });

--- a/resources/assets/js/settings/teams/team-settings.js
+++ b/resources/assets/js/settings/teams/team-settings.js
@@ -50,7 +50,7 @@ module.exports = {
          * Get the team being managed.
          */
         getTeam() {
-            this.$http.get(`/teams/${this.teamId}`)
+            this.$http.get(`/${Spark.teamStringPlural}/${this.teamId}`)
                 .then(response => {
                     this.team = response.data;
                 });

--- a/resources/assets/js/settings/teams/update-team-name.js
+++ b/resources/assets/js/settings/teams/update-team-name.js
@@ -26,7 +26,7 @@ module.exports = {
          * Update the team name.
          */
         update() {
-            Spark.put(`/settings/teams/${this.team.id}/name`, this.form)
+            Spark.put(`/settings/${Spark.teamStringPlural}/${this.team.id}/name`, this.form)
                 .then(() => {
                     this.$dispatch('updateTeam');
                     this.$dispatch('updateTeams');

--- a/resources/assets/js/settings/teams/update-team-photo.js
+++ b/resources/assets/js/settings/teams/update-team-photo.js
@@ -66,7 +66,7 @@ module.exports = {
          * Get the URL for updating the team photo.
          */
         urlForUpdate() {
-            return `/settings/teams/${this.team.id}/photo`;
+            return `/settings/${Spark.teamStringPlural}/${this.team.id}/photo`;
         },
 
 

--- a/resources/assets/js/spark.js
+++ b/resources/assets/js/spark.js
@@ -156,7 +156,7 @@ module.exports = {
          * Get the current team list.
          */
         getTeams() {
-            this.$http.get('/teams')
+            this.$http.get('/'+Spark.teamStringPlural)
                 .then(response => {
                     this.teams = response.data;
                 });
@@ -167,7 +167,7 @@ module.exports = {
          * Get the current team.
          */
         getCurrentTeam() {
-            this.$http.get('/teams/current')
+            this.$http.get(`/${Spark.teamStringPlural}/current`)
                 .then(response => {
                     this.currentTeam = response.data;
                 })

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'eligibility' => 'You are not eligible for this plan based on your current number of teams / team members.'
+    'eligibility' => 'You are not eligible for this plan based on your current number of '.str_plural(Spark::teamString()).' / '.Spark::teamString().' members.'
 ];

--- a/resources/views/auth/register-common-form.blade.php
+++ b/resources/views/auth/register-common-form.blade.php
@@ -2,7 +2,7 @@
     <!-- Team Name -->
     @if (Spark::usesTeams())
         <div class="form-group" :class="{'has-error': registerForm.errors.has('team')}" v-if=" ! invitation">
-            <label class="col-md-4 control-label">Team Name</label>
+            <label class="col-md-4 control-label">{{ucfirst(Spark::teamString())}} Name</label>
 
             <div class="col-md-6">
                 <input type="name" class="form-control" name="team" v-model="registerForm.team" autofocus>

--- a/resources/views/kiosk/profile.blade.php
+++ b/resources/views/kiosk/profile.blade.php
@@ -92,7 +92,7 @@
                 <div class="col-md-12">
                     <div class="panel panel-default">
                         <div class="panel-heading">
-                            Teams
+                            {{ucfirst(str_plural(Spark::teamString()))}}
                         </div>
 
                         <div class="panel-body">

--- a/resources/views/missing-team.blade.php
+++ b/resources/views/missing-team.blade.php
@@ -5,10 +5,10 @@
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
             <div class="panel panel-warning">
-                <div class="panel-heading">Where's Your Team?</div>
+                <div class="panel-heading">Where's Your {{ucfirst(Spark::teamString())}}?</div>
 
                 <div class="panel-body">
-                    It looks like you're not part of a team! You can create one in your
+                    It looks like you're not part of a {{Spark::teamString()}}! You can create one in your
                     <a href="/settings#/teams">settings</a>.
                 </div>
             </div>

--- a/resources/views/nav/blade/teams.blade.php
+++ b/resources/views/nav/blade/teams.blade.php
@@ -1,12 +1,12 @@
 <li class="divider"></li>
 
 <!-- Teams -->
-<li class="dropdown-header">Teams</li>
+<li class="dropdown-header">{{ucfirst(str_plural(Spark::teamString()))}}</li>
 
 <!-- Create Team -->
 <li>
     <a href="/settings#/teams">
-        <i class="fa fa-fw fa-btn fa-plus"></i>Create Team
+        <i class="fa fa-fw fa-btn fa-plus"></i>Create {{ucfirst(Spark::teamString())}}
     </a>
 </li>
 

--- a/resources/views/nav/subscriptions.blade.php
+++ b/resources/views/nav/subscriptions.blade.php
@@ -13,7 +13,7 @@
 
 @if (Spark::usesTeams() && Auth::user()->currentTeamOnTrial())
     <!-- Team Trial Reminder -->
-    <li class="dropdown-header">Team Trial</li>
+    <li class="dropdown-header">{{ucfirst(Spark::teamString())}} Trial</li>
 
     <li>
         <a href="/settings/teams/{{ Auth::user()->currentTeam()->id }}#/subscription">

--- a/resources/views/nav/teams.blade.php
+++ b/resources/views/nav/teams.blade.php
@@ -1,13 +1,13 @@
 <li class="divider"></li>
 
 <!-- Teams -->
-<li class="dropdown-header">Teams</li>
+<li class="dropdown-header">{{ucfirst(str_plural(Spark::teamString()))}}</li>
 
 <!-- Create Team -->
 @if (Spark::createsAdditionalTeams())
     <li>
         <a href="/settings#/teams">
-            <i class="fa fa-fw fa-btn fa-plus"></i>Create Team
+            <i class="fa fa-fw fa-btn fa-plus"></i>Create {{ucfirst(Spark::teamString())}}
         </a>
     </li>
 @endif

--- a/resources/views/nav/teams.blade.php
+++ b/resources/views/nav/teams.blade.php
@@ -6,7 +6,7 @@
 <!-- Create Team -->
 @if (Spark::createsAdditionalTeams())
     <li>
-        <a href="/settings#/teams">
+        <a href="/settings#/{{str_plural(Spark::teamString())}}">
             <i class="fa fa-fw fa-btn fa-plus"></i>Create {{ucfirst(Spark::teamString())}}
         </a>
     </li>
@@ -14,7 +14,7 @@
 
 <!-- Switch Current Team -->
 <li v-for="team in teams">
-    <a href="/teams/@{{ team.id }}/switch">
+    <a href="/{{str_plural(Spark::teamString())}}/@{{ team.id }}/switch">
         <span v-if="user.current_team_id == team.id">
             <i class="fa fa-fw fa-btn fa-check text-success"></i>@{{ team.name }}
         </span>

--- a/resources/views/settings.blade.php
+++ b/resources/views/settings.blade.php
@@ -32,8 +32,8 @@
                                 <!-- Teams Link -->
                                 @if (Spark::usesTeams())
                                     <li role="presentation">
-                                        <a href="#teams" aria-controls="teams" role="tab" data-toggle="tab">
-                                            <i class="fa fa-fw fa-btn fa-users"></i>{{ucfirst(Spark::teamString())}}
+                                        <a href="#{{str_plural(Spark::teamString())}}" aria-controls="teams" role="tab" data-toggle="tab">
+                                            <i class="fa fa-fw fa-btn fa-users"></i>{{ucfirst(str_plural(Spark::teamString()))}}
                                         </a>
                                     </li>
                                 @endif
@@ -107,7 +107,7 @@
 
                     <!-- Teams -->
                     @if (Spark::usesTeams())
-                        <div role="tabpanel" class="tab-pane" id="teams">
+                        <div role="tabpanel" class="tab-pane" id="{{str_plural(Spark::teamString())}}">
                             @include('spark::settings.teams')
                         </div>
                     @endif

--- a/resources/views/settings.blade.php
+++ b/resources/views/settings.blade.php
@@ -33,7 +33,7 @@
                                 @if (Spark::usesTeams())
                                     <li role="presentation">
                                         <a href="#teams" aria-controls="teams" role="tab" data-toggle="tab">
-                                            <i class="fa fa-fw fa-btn fa-users"></i>Teams
+                                            <i class="fa fa-fw fa-btn fa-users"></i>{{ucfirst(Spark::teamString())}}
                                         </a>
                                     </li>
                                 @endif

--- a/resources/views/settings/teams/create-team.blade.php
+++ b/resources/views/settings/teams/create-team.blade.php
@@ -1,12 +1,12 @@
 <spark-create-team inline-template>
     <div class="panel panel-default">
-        <div class="panel-heading">Create Team</div>
+        <div class="panel-heading">Create {{ucfirst(Spark::teamString())}}</div>
 
         <div class="panel-body">
             <form class="form-horizontal" role="form">
                 <!-- Name -->
                 <div class="form-group" :class="{'has-error': form.errors.has('name')}">
-                    <label class="col-md-4 control-label">Team Name</label>
+                    <label class="col-md-4 control-label">{{ucfirst(Spark::teamString())}} Name</label>
 
                     <div class="col-md-6">
                         <input type="text" id="create-team-name" class="form-control" name="name" v-model="form.name">

--- a/resources/views/settings/teams/current-teams.blade.php
+++ b/resources/views/settings/teams/current-teams.blade.php
@@ -42,7 +42,7 @@
 
                             <!-- Edit Button -->
                             <td>
-                                <a href="/settings/teams/@{{ team.id }}">
+                                <a href="/settings/{{str_plural(Spark::teamString())}}/@{{ team.id }}">
                                     <button class="btn btn-primary">
                                         <i class="fa fa-cog"></i>
                                     </button>

--- a/resources/views/settings/teams/current-teams.blade.php
+++ b/resources/views/settings/teams/current-teams.blade.php
@@ -1,7 +1,7 @@
 <spark-current-teams :user="user" :teams="teams" inline-template>
     <div>
         <div class="panel panel-default">
-            <div class="panel-heading">Current Teams</div>
+            <div class="panel-heading">Current {{ucfirst(str_plural(Spark::teamString()))}}</div>
 
             <div class="panel-body">
                 <table class="table table-borderless m-b-none">
@@ -78,12 +78,12 @@
                         <button type="button " class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 
                         <h4 class="modal-title">
-                            Leave Team (@{{ leavingTeam.name }})
+                            Leave {{ucfirst(Spark::teamString())}} (@{{ leavingTeam.name }})
                         </h4>
                     </div>
 
                     <div class="modal-body">
-                        Are you sure you want to leave this team?
+                        Are you sure you want to leave this {{Spark::teamString()}}?
                     </div>
 
                     <!-- Modal Actions -->
@@ -106,13 +106,13 @@
                         <button type="button " class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 
                         <h4 class="modal-title">
-                            Delete Team (@{{ deletingTeam.name }})
+                            Delete {{ucfirst(Spark::teamString())}} (@{{ deletingTeam.name }})
                         </h4>
                     </div>
 
                     <div class="modal-body">
-                        Are you sure you want to delete this team? If you choose to delete the team, all of the
-                        team's data will be permanently deleted.
+                        Are you sure you want to delete this {{Spark::teamString()}}? If you choose to delete the {{Spark::teamString()}}, all of the
+                        {{Spark::teamString()}}'s data will be permanently deleted.
                     </div>
 
                     <!-- Modal Actions -->

--- a/resources/views/settings/teams/emails/invitation-to-existing-user.blade.php
+++ b/resources/views/settings/teams/emails/invitation-to-existing-user.blade.php
@@ -2,7 +2,7 @@ Hi!
 
 <br><br>
 
-{{ $invitation->team->owner->name }} has invited you to join their team!
+{{ $invitation->team->owner->name }} has invited you to join their {{Spark::teamString()}}!
 
 <br><br>
 

--- a/resources/views/settings/teams/emails/invitation-to-new-user.blade.php
+++ b/resources/views/settings/teams/emails/invitation-to-new-user.blade.php
@@ -2,7 +2,7 @@ Hi!
 
 <br><br>
 
-{{ $invitation->team->owner->name }} has invited you to join their team! If you do not already have an account,
+{{ $invitation->team->owner->name }} has invited you to join their {{Spark::teamString()}}! If you do not already have an account,
 you may click the following link to get started:
 
 <br><br>

--- a/resources/views/settings/teams/pending-invitations.blade.php
+++ b/resources/views/settings/teams/pending-invitations.blade.php
@@ -6,7 +6,7 @@
             <div class="panel-body">
                 <table class="table table-borderless m-b-none">
                     <thead>
-                        <th>Team</th>
+                        <th>{{ucfirst(Spark::teamString())}}</th>
                         <th></th>
                         <th></th>
                     </thead>

--- a/resources/views/settings/teams/team-members.blade.php
+++ b/resources/views/settings/teams/team-members.blade.php
@@ -1,7 +1,7 @@
 <spark-team-members :user="user" :team="team" inline-template>
     <div>
         <div class="panel panel-default">
-            <div class="panel-heading">Team Members (@{{ team.users.length }})</div>
+            <div class="panel-heading">{{ucfirst(Spark::teamString())}} Members (@{{ team.users.length }})</div>
 
             <div class="panel-body">
                 <table class="table table-borderless m-b-none">
@@ -73,7 +73,7 @@
                         <button type="button " class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 
                         <h4 class="modal-title">
-                            Edit Team Member (@{{ updatingTeamMember.name }})
+                            Edit {{ucfirst(Spark::teamString())}} Member (@{{ updatingTeamMember.name }})
                         </h4>
                     </div>
 
@@ -81,7 +81,7 @@
                         <!-- Update Team Member Form -->
                         <form class="form-horizontal" role="form">
                             <div class="form-group" :class="{'has-error': updateTeamMemberForm.errors.has('role')}">
-                                <label class="col-md-4 control-label">Team Member Role</label>
+                                <label class="col-md-4 control-label">{{ucfirst(Spark::teamString())}} Member Role</label>
 
                                 <div class="col-md-6">
                                     <select class="form-control" v-model="updateTeamMemberForm.role">
@@ -118,12 +118,12 @@
                         <button type="button " class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 
                         <h4 class="modal-title">
-                            Remove Team Member (@{{ deletingTeamMember.name }})
+                            Remove {{ucfirst(Spark::teamString())}} Member (@{{ deletingTeamMember.name }})
                         </h4>
                     </div>
 
                     <div class="modal-body">
-                        Are you sure you want to remove this team member?
+                        Are you sure you want to remove this {{ucfirst(Spark::teamString())}} member?
                     </div>
 
                     <!-- Modal Actions -->

--- a/resources/views/settings/teams/team-settings.blade.php
+++ b/resources/views/settings/teams/team-settings.blade.php
@@ -17,7 +17,7 @@
                 <div class="panel panel-default panel-flush">
                     <div class="panel-heading">
                         <span v-if="team">
-                            @{{ team.name }} Team Settings
+                            @{{ team.name }} {{ucfirst(Spark::teamString())}} Settings
                         </span>
                     </div>
 
@@ -28,7 +28,7 @@
                                 @if (Auth::user()->ownsTeam($team))
                                     <li role="presentation" class="active">
                                         <a href="#owner" aria-controls="owner" role="tab" data-toggle="tab">
-                                            <i class="fa fa-fw fa-btn fa-edit"></i>Team Profile
+                                            <i class="fa fa-fw fa-btn fa-edit"></i>{{ucfirst(Spark::teamString())}} Profile
                                         </a>
                                     </li>
                                 @endif
@@ -47,7 +47,7 @@
                                 <!-- View All Teams -->
                                 <li role="presentation">
                                     <a href="/settings#/teams">
-                                        <i class="fa fa-fw fa-btn fa-arrow-left"></i>View All Teams
+                                        <i class="fa fa-fw fa-btn fa-arrow-left"></i>View All {{ucfirst(str_plural(Spark::teamString()))}}
                                     </a>
                                 </li>
                             </ul>
@@ -59,7 +59,7 @@
                 @if (Spark::canBillTeams() && Auth::user()->ownsTeam($team))
                     <div class="panel panel-default panel-flush">
                         <div class="panel-heading">
-                            Team Billing
+                            {{ucfirst(Spark::teamString())}} Billing
                         </div>
 
                         <div class="panel-body">

--- a/resources/views/settings/teams/team-settings.blade.php
+++ b/resources/views/settings/teams/team-settings.blade.php
@@ -46,7 +46,7 @@
 
                                 <!-- View All Teams -->
                                 <li role="presentation">
-                                    <a href="/settings#/teams">
+                                    <a href="/settings#/{{str_plural(Spark::teamString())}}">
                                         <i class="fa fa-fw fa-btn fa-arrow-left"></i>View All {{ucfirst(str_plural(Spark::teamString()))}}
                                     </a>
                                 </li>

--- a/resources/views/settings/teams/update-team-name.blade.php
+++ b/resources/views/settings/teams/update-team-name.blade.php
@@ -1,11 +1,11 @@
 <spark-update-team-name :user="user" :team="team" inline-template>
     <div class="panel panel-default">
-        <div class="panel-heading">Update Team Name</div>
+        <div class="panel-heading">Update {{ucfirst(Spark::teamString())}} Name</div>
 
         <div class="panel-body">
             <!-- Success Message -->
             <div class="alert alert-success" v-if="form.successful">
-                Your team name has been updated!
+                Your {{Spark::teamString()}} name has been updated!
             </div>
 
             <form class="form-horizontal" role="form">

--- a/resources/views/settings/teams/update-team-photo.blade.php
+++ b/resources/views/settings/teams/update-team-photo.blade.php
@@ -1,7 +1,7 @@
 <spark-update-team-photo :user="user" :team="team" inline-template>
     <div>
         <div class="panel panel-default">
-            <div class="panel-heading">Team Photo</div>
+            <div class="panel-heading">{{ucfirst(Spark::teamString())}} Photo</div>
 
             <div class="panel-body">
                 <div class="alert alert-danger" v-if="form.errors.has('photo')">

--- a/src/Configuration/ManagesModelOptions.php
+++ b/src/Configuration/ManagesModelOptions.php
@@ -28,6 +28,13 @@ trait ManagesModelOptions
     public static $createsAdditionalTeams = true;
 
     /**
+     * The name used in the URI and interface to describe a team.
+     *
+     * @var string
+     */
+    public static $teamString = 'team';
+
+    /**
      * Set the user model class name.
      *
      * @param  string  $userModel
@@ -117,5 +124,26 @@ trait ManagesModelOptions
     public static function noAdditionalTeams()
     {
         static::$createsAdditionalTeams = false;
+    }
+
+    /**
+     * Set the string used to describe a team.
+     *
+     * @param  string  $string
+     * @return void
+     */
+    public static function setTeamString($string)
+    {
+        static::$teamString = $string;
+    }
+
+    /**
+     * Get the string used to describe a team..
+     *
+     * @return string
+     */
+    public static function teamString()
+    {
+        return static::$teamString;
     }
 }

--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -30,6 +30,8 @@ trait ProvidesScriptVariables
             'roles' => Spark::roles(),
             'state' => Spark::call(InitialFrontendState::class.'@forUser', [Auth::user()]),
             'stripeKey' => config('services.stripe.key'),
+            'teamString' => Spark::teamString(),
+            'teamStringPlural' => str_plural(Spark::teamString()),
             'userId' => Auth::id(),
             'usesApi' => Spark::usesApi(),
             'usesBraintree' => Spark::billsUsingBraintree(),

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,6 +1,10 @@
 <?php
 
 $router->group(['middleware' => 'web'], function ($router) {
+    $teamString = Spark::teamString();
+
+    $teamStringPlural = str_plural(Spark::teamString());
+
     // Terms Of Service...
     $router->get('/terms', 'TermsController@show');
 
@@ -33,29 +37,29 @@ $router->group(['middleware' => 'web'], function ($router) {
     // Teams...
     if (Spark::usesTeams()) {
         // General Settings...
-        $router->get('/settings/'.str_plural(Spark::teamString()).'/roles', 'Settings\Teams\TeamMemberRoleController@all');
-        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}', 'Settings\Teams\DashboardController@show');
+        $router->get('/settings/'.$teamStringPlural.'/roles', 'Settings\Teams\TeamMemberRoleController@all');
+        $router->get('/settings/'.$teamStringPlural.'/{team}', 'Settings\Teams\DashboardController@show');
 
-        $router->get('/'.str_plural(Spark::teamString()).'', 'TeamController@all');
-        $router->get('/'.str_plural(Spark::teamString()).'/current', 'TeamController@current');
-        $router->get('/'.str_plural(Spark::teamString()).'/{team_id}', 'TeamController@show');
-        $router->post('/settings/'.str_plural(Spark::teamString()).'', 'Settings\Teams\TeamController@store');
-        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/photo', 'Settings\Teams\TeamPhotoController@update');
-        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/name', 'Settings\Teams\TeamNameController@update');
+        $router->get('/'.$teamStringPlural.'', 'TeamController@all');
+        $router->get('/'.$teamStringPlural.'/current', 'TeamController@current');
+        $router->get('/'.$teamStringPlural.'/{team_id}', 'TeamController@show');
+        $router->post('/settings/'.$teamStringPlural.'', 'Settings\Teams\TeamController@store');
+        $router->post('/settings/'.$teamStringPlural.'/{team}/photo', 'Settings\Teams\TeamPhotoController@update');
+        $router->put('/settings/'.$teamStringPlural.'/{team}/name', 'Settings\Teams\TeamNameController@update');
 
         // Invitations...
-        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}/invitations', 'Settings\Teams\MailedInvitationController@all');
-        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/invitations', 'Settings\Teams\MailedInvitationController@store');
+        $router->get('/settings/'.$teamStringPlural.'/{team}/invitations', 'Settings\Teams\MailedInvitationController@all');
+        $router->post('/settings/'.$teamStringPlural.'/{team}/invitations', 'Settings\Teams\MailedInvitationController@store');
         $router->get('/settings/invitations/pending', 'Settings\Teams\PendingInvitationController@all');
         $router->get('/invitations/{invitation}', 'InvitationController@show');
         $router->post('/settings/invitations/{invitation}/accept', 'Settings\Teams\PendingInvitationController@accept');
         $router->post('/settings/invitations/{invitation}/reject', 'Settings\Teams\PendingInvitationController@reject');
         $router->delete('/settings/invitations/{invitation}', 'Settings\Teams\MailedInvitationController@destroy');
 
-        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@update');
-        $router->delete('/settings/'.str_plural(Spark::teamString()).'/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@destroy');
-        $router->delete('/settings/'.str_plural(Spark::teamString()).'/{team}', 'Settings\Teams\TeamController@destroy');
-        $router->get('/'.str_plural(Spark::teamString()).'/{team}/switch', 'TeamController@switchCurrentTeam');
+        $router->put('/settings/'.$teamStringPlural.'/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@update');
+        $router->delete('/settings/'.$teamStringPlural.'/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@destroy');
+        $router->delete('/settings/'.$teamStringPlural.'/{team}', 'Settings\Teams\TeamController@destroy');
+        $router->get('/'.$teamStringPlural.'/{team}/switch', 'TeamController@switchCurrentTeam');
 
         // Billing
 
@@ -63,31 +67,31 @@ $router->group(['middleware' => 'web'], function ($router) {
         $router->get('/spark/team-plans', 'TeamPlanController@all');
 
         // Subscription Settings...
-        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@store');
-        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@update');
-        $router->delete('/settings/'.str_plural(Spark::teamString()).'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@destroy');
+        $router->post('/settings/'.$teamStringPlural.'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@store');
+        $router->put('/settings/'.$teamStringPlural.'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@update');
+        $router->delete('/settings/'.$teamStringPlural.'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@destroy');
 
         // VAT ID Settings...
-        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/payment-method/vat-id', 'Settings\Teams\PaymentMethod\VatIdController@update');
+        $router->put('/settings/'.$teamStringPlural.'/{team}/payment-method/vat-id', 'Settings\Teams\PaymentMethod\VatIdController@update');
 
         // Credit Card Settings...
-        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/payment-method', 'Settings\Teams\PaymentMethod\PaymentMethodController@update');
+        $router->put('/settings/'.$teamStringPlural.'/{team}/payment-method', 'Settings\Teams\PaymentMethod\PaymentMethodController@update');
 
         // Redeem Coupon...
-        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/payment-method/coupon', 'Settings\Teams\PaymentMethod\RedeemCouponController@redeem');
+        $router->post('/settings/'.$teamStringPlural.'/{team}/payment-method/coupon', 'Settings\Teams\PaymentMethod\RedeemCouponController@redeem');
 
         // Billing History...
         $router->put(
-            '/settings/'.str_plural(Spark::teamString()).'/{team}/extra-billing-information',
+            '/settings/'.$teamStringPlural.'/{team}/extra-billing-information',
             'Settings\Teams\Billing\BillingInformationController@update'
         );
 
         // Coupons...
-        $router->get('/coupon/'.Spark::teamString().'/{id}', 'TeamCouponController@current');
+        $router->get('/coupon/'.$teamString.'/{id}', 'TeamCouponController@current');
 
         // Invoices...
-        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}/invoices', 'Settings\Teams\Billing\InvoiceController@all');
-        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}/invoice/{id}', 'Settings\Teams\Billing\InvoiceController@download');
+        $router->get('/settings/'.$teamStringPlural.'/{team}/invoices', 'Settings\Teams\Billing\InvoiceController@all');
+        $router->get('/settings/'.$teamStringPlural.'/{team}/invoice/{id}', 'Settings\Teams\Billing\InvoiceController@download');
     }
 
     // Security Settings...

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -9,7 +9,7 @@ $router->group(['middleware' => 'web'], function ($router) {
     $router->get('/terms', 'TermsController@show');
 
     // Missing Team Notice...
-    $router->get('/missing-team', 'MissingTeamController@show');
+    $router->get('/missing-'.$teamString, 'MissingTeamController@show');
 
     // Customer Support...
     $router->post('/support/email', 'SupportController@sendEmail');
@@ -64,7 +64,7 @@ $router->group(['middleware' => 'web'], function ($router) {
         // Billing
 
         // Plans...
-        $router->get('/spark/team-plans', 'TeamPlanController@all');
+        $router->get('/spark/'.$teamString.'-plans', 'TeamPlanController@all');
 
         // Subscription Settings...
         $router->post('/settings/'.$teamStringPlural.'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@store');

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -33,29 +33,29 @@ $router->group(['middleware' => 'web'], function ($router) {
     // Teams...
     if (Spark::usesTeams()) {
         // General Settings...
-        $router->get('/settings/teams/roles', 'Settings\Teams\TeamMemberRoleController@all');
-        $router->get('/settings/teams/{team}', 'Settings\Teams\DashboardController@show');
+        $router->get('/settings/'.str_plural(Spark::teamString()).'/roles', 'Settings\Teams\TeamMemberRoleController@all');
+        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}', 'Settings\Teams\DashboardController@show');
 
-        $router->get('/teams', 'TeamController@all');
-        $router->get('/teams/current', 'TeamController@current');
-        $router->get('/teams/{team_id}', 'TeamController@show');
-        $router->post('/settings/teams', 'Settings\Teams\TeamController@store');
-        $router->post('/settings/teams/{team}/photo', 'Settings\Teams\TeamPhotoController@update');
-        $router->put('/settings/teams/{team}/name', 'Settings\Teams\TeamNameController@update');
+        $router->get('/'.str_plural(Spark::teamString()).'', 'TeamController@all');
+        $router->get('/'.str_plural(Spark::teamString()).'/current', 'TeamController@current');
+        $router->get('/'.str_plural(Spark::teamString()).'/{team_id}', 'TeamController@show');
+        $router->post('/settings/'.str_plural(Spark::teamString()).'', 'Settings\Teams\TeamController@store');
+        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/photo', 'Settings\Teams\TeamPhotoController@update');
+        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/name', 'Settings\Teams\TeamNameController@update');
 
         // Invitations...
-        $router->get('/settings/teams/{team}/invitations', 'Settings\Teams\MailedInvitationController@all');
-        $router->post('/settings/teams/{team}/invitations', 'Settings\Teams\MailedInvitationController@store');
+        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}/invitations', 'Settings\Teams\MailedInvitationController@all');
+        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/invitations', 'Settings\Teams\MailedInvitationController@store');
         $router->get('/settings/invitations/pending', 'Settings\Teams\PendingInvitationController@all');
         $router->get('/invitations/{invitation}', 'InvitationController@show');
         $router->post('/settings/invitations/{invitation}/accept', 'Settings\Teams\PendingInvitationController@accept');
         $router->post('/settings/invitations/{invitation}/reject', 'Settings\Teams\PendingInvitationController@reject');
         $router->delete('/settings/invitations/{invitation}', 'Settings\Teams\MailedInvitationController@destroy');
 
-        $router->put('/settings/teams/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@update');
-        $router->delete('/settings/teams/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@destroy');
-        $router->delete('/settings/teams/{team}', 'Settings\Teams\TeamController@destroy');
-        $router->get('/teams/{team}/switch', 'TeamController@switchCurrentTeam');
+        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@update');
+        $router->delete('/settings/'.str_plural(Spark::teamString()).'/{team}/members/{team_member}', 'Settings\Teams\TeamMemberController@destroy');
+        $router->delete('/settings/'.str_plural(Spark::teamString()).'/{team}', 'Settings\Teams\TeamController@destroy');
+        $router->get('/'.str_plural(Spark::teamString()).'/{team}/switch', 'TeamController@switchCurrentTeam');
 
         // Billing
 
@@ -63,31 +63,31 @@ $router->group(['middleware' => 'web'], function ($router) {
         $router->get('/spark/team-plans', 'TeamPlanController@all');
 
         // Subscription Settings...
-        $router->post('/settings/teams/{team}/subscription', 'Settings\Teams\Subscription\PlanController@store');
-        $router->put('/settings/teams/{team}/subscription', 'Settings\Teams\Subscription\PlanController@update');
-        $router->delete('/settings/teams/{team}/subscription', 'Settings\Teams\Subscription\PlanController@destroy');
+        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@store');
+        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@update');
+        $router->delete('/settings/'.str_plural(Spark::teamString()).'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@destroy');
 
         // VAT ID Settings...
-        $router->put('/settings/teams/{team}/payment-method/vat-id', 'Settings\Teams\PaymentMethod\VatIdController@update');
+        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/payment-method/vat-id', 'Settings\Teams\PaymentMethod\VatIdController@update');
 
         // Credit Card Settings...
-        $router->put('/settings/teams/{team}/payment-method', 'Settings\Teams\PaymentMethod\PaymentMethodController@update');
+        $router->put('/settings/'.str_plural(Spark::teamString()).'/{team}/payment-method', 'Settings\Teams\PaymentMethod\PaymentMethodController@update');
 
         // Redeem Coupon...
-        $router->post('/settings/teams/{team}/payment-method/coupon', 'Settings\Teams\PaymentMethod\RedeemCouponController@redeem');
+        $router->post('/settings/'.str_plural(Spark::teamString()).'/{team}/payment-method/coupon', 'Settings\Teams\PaymentMethod\RedeemCouponController@redeem');
 
         // Billing History...
         $router->put(
-            '/settings/teams/{team}/extra-billing-information',
+            '/settings/'.str_plural(Spark::teamString()).'/{team}/extra-billing-information',
             'Settings\Teams\Billing\BillingInformationController@update'
         );
 
         // Coupons...
-        $router->get('/coupon/team/{id}', 'TeamCouponController@current');
+        $router->get('/coupon/'.Spark::teamString().'/{id}', 'TeamCouponController@current');
 
         // Invoices...
-        $router->get('/settings/teams/{team}/invoices', 'Settings\Teams\Billing\InvoiceController@all');
-        $router->get('/settings/teams/{team}/invoice/{id}', 'Settings\Teams\Billing\InvoiceController@download');
+        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}/invoices', 'Settings\Teams\Billing\InvoiceController@all');
+        $router->get('/settings/'.str_plural(Spark::teamString()).'/{team}/invoice/{id}', 'Settings\Teams\Billing\InvoiceController@download');
     }
 
     // Security Settings...

--- a/src/Interactions/Settings/Teams/CreateTeam.php
+++ b/src/Interactions/Settings/Teams/CreateTeam.php
@@ -45,7 +45,7 @@ class CreateTeam implements Contract
         }
 
         if ($plan->teams <= $user->ownedTeams()->count()) {
-            $validator->errors()->add('name', 'Please upgrade your subscription to create more teams.');
+            $validator->errors()->add('name', 'Please upgrade your subscription to create more '.str_plural(Spark::teamString()).'.');
         }
     }
 


### PR DESCRIPTION
This PR allows setting a customized name for the team:

```
public function register()
{
    Spark::setTeamString('band');
}
```

This will results all urls to be changed to `band` and `bands`, also all instances of team inside the UI will be changed to `band` and `bands`.

Note: Pluralisation is done via `str_plural()`.
