### PR TITLE
set the closure scope to be the same as the interaction

### DIFF
--- a/src/Configuration/CallsInteractions.php
+++ b/src/Configuration/CallsInteractions.php
@@ -69,7 +69,9 @@ trait CallsInteractions
             return static::interact(static::$interactions[$interaction], $parameters);
         }
 
-        $method = static::$interactions[$interaction]->bindTo(app($class));
+        $instance = app($class);
+
+        $method = static::$interactions[$interaction]->bindTo($instance, $instance);
 
         return call_user_func_array($method, $parameters);
     }


### PR DESCRIPTION
This will allow calling private properties and methods from within the closure.

This is the issue I'm trying to fix: https://github.com/laravel/spark/issues/288
