### PR TITLE
Add row in the metrics screen for people on generic trial

### DIFF
--- a/resources/views/kiosk/metrics.blade.php
+++ b/resources/views/kiosk/metrics.blade.php
@@ -143,9 +143,15 @@
 
                             <tbody>
                                 <tr v-if="genericTrialUsers">
-                                    <td colspan="2">
+                                    <td>
                                         <div class="btn-table-align">
                                             On Generic Trial
+                                        </div>
+                                    </td>
+
+                                    <td>
+                                        <div class="btn-table-align">
+                                            N/A
                                         </div>
                                     </td>
 

--- a/resources/views/kiosk/metrics.blade.php
+++ b/resources/views/kiosk/metrics.blade.php
@@ -150,14 +150,8 @@
                                         </div>
                                     </td>
 
-                                    <!-- Subscriber Count -->
-                                    <td>
-                                        <div class="btn-table-align">
+                                    <td></td>
 
-                                        </div>
-                                    </td>
-
-                                    <!-- Trialing Count -->
                                     <td>
                                         <div class="btn-table-align">
                                             @{{ genericTrialUsers }}

--- a/resources/views/kiosk/metrics.blade.php
+++ b/resources/views/kiosk/metrics.blade.php
@@ -131,7 +131,7 @@
         <div class="row" v-if="plans.length > 0">
             <div class="col-md-12">
                 <div class="panel panel-default">
-                    <div class="panel-heading">Subscribers Per Plan</div>
+                    <div class="panel-heading">Subscribers</div>
 
                     <div class="panel-body">
                         <table class="table table-borderless m-b-none">
@@ -142,6 +142,28 @@
                             </thead>
 
                             <tbody>
+                                <tr v-if="genericTrialUsers">
+                                    <!-- Plan Name -->
+                                    <td>
+                                        <div class="btn-table-align">
+                                            On Generic Trial
+                                        </div>
+                                    </td>
+
+                                    <!-- Subscriber Count -->
+                                    <td>
+                                        <div class="btn-table-align">
+
+                                        </div>
+                                    </td>
+
+                                    <!-- Trialing Count -->
+                                    <td>
+                                        <div class="btn-table-align">
+                                            @{{ genericTrialUsers }}
+                                        </div>
+                                    </td>
+                                </tr>
                                 <tr v-for="plan in plans">
                                     <!-- Plan Name -->
                                     <td>

--- a/resources/views/kiosk/metrics.blade.php
+++ b/resources/views/kiosk/metrics.blade.php
@@ -143,14 +143,11 @@
 
                             <tbody>
                                 <tr v-if="genericTrialUsers">
-                                    <!-- Plan Name -->
-                                    <td>
+                                    <td colspan="2">
                                         <div class="btn-table-align">
                                             On Generic Trial
                                         </div>
                                     </td>
-
-                                    <td></td>
 
                                     <td>
                                         <div class="btn-table-align">


### PR DESCRIPTION
This PR displays a row that specifies the number of users on generic trial, this will eliminate the confusion described in this issue: https://github.com/laravel/spark/issues/285

<img width="828" alt="screen shot 2016-09-23 at 7 59 00 pm" src="https://cloud.githubusercontent.com/assets/4332182/18796010/a2b17a1e-81c7-11e6-9791-a4f53104d197.png">
