### PR TITLE
Show hints about team and invitations limits

### DIFF
--- a/resources/assets/js/settings/teams/send-invitation.js
+++ b/resources/assets/js/settings/teams/send-invitation.js
@@ -6,10 +6,87 @@ module.exports = {
      */
     data() {
         return {
+            plans: [],
+
             form: new SparkForm({
                 email: ''
             })
         };
+    },
+
+
+    computed: {
+        /**
+         * Get the active subscription instance.
+         */
+        activeSubscription() {
+            if ( ! this.$parent.billable) {
+                return;
+            }
+
+            const subscription = _.find(
+                this.$parent.billable.subscriptions,
+                subscription => subscription.name == 'default'
+            );
+
+            if (typeof subscription !== 'undefined') {
+                return subscription;
+            }
+        },
+
+
+        /**
+         * Get the active plan instance.
+         */
+        activePlan() {
+            if (this.activeSubscription) {
+                return _.find(this.plans, (plan) => {
+                    return plan.id == this.activeSubscription.provider_plan;
+                });
+            }
+        },
+
+
+        /**
+         * Check if there's a limit for the number of team members.
+         */
+        hasTeamMembersLimit() {
+            if (! this.activePlan) {
+                return false;
+            }
+
+            return !! this.activePlan.attributes.teamMembers;
+        },
+
+
+        /**
+         *
+         * Get the remaining team members in the active plan.
+         */
+        remainingTeamMembers() {
+            return this.activePlan
+                    ? this.activePlan.attributes.teamMembers - this.$parent.team.users.length
+                    : 0;
+        },
+
+
+        /**
+         * Check if the user can invite more team members.
+         */
+        canInviteMoreTeamMembers() {
+            if (! this.hasTeamMembersLimit) {
+                return true;
+            }
+            return this.remainingTeamMembers > 0;
+        }
+    },
+
+
+    /**
+     * The component has been created by Vue.
+     */
+    created() {
+        this.getPlans();
     },
 
 
@@ -23,6 +100,16 @@ module.exports = {
                     this.form.email = '';
 
                     this.$dispatch('updateInvitations');
+                });
+        },
+
+        /**
+         * Get all the plans defined in the application.
+         */
+        getPlans() {
+            this.$http.get('/spark/plans')
+                .then(response => {
+                    this.plans = response.data;
                 });
         }
     }

--- a/resources/views/settings/teams/create-team.blade.php
+++ b/resources/views/settings/teams/create-team.blade.php
@@ -3,14 +3,16 @@
         <div class="panel-heading">Create {{ucfirst(Spark::teamString())}}</div>
 
         <div class="panel-body">
-            <form class="form-horizontal" role="form">
+            <form class="form-horizontal" role="form" v-if="canCreateMoreTeams">
                 <!-- Name -->
                 <div class="form-group" :class="{'has-error': form.errors.has('name')}">
                     <label class="col-md-4 control-label">{{ ucfirst(Spark::teamString()) }} Name</label>
 
                     <div class="col-md-6">
                         <input type="text" id="create-team-name" class="form-control" name="name" v-model="form.name">
-
+                        <span class="help-block" v-if="hasTeamLimit">
+                            You currently have @{{ remainingTeams }} teams remaining.
+                        </span>
                         <span class="help-block" v-show="form.errors.has('name')">
                             @{{ form.errors.get('name') }}
                         </span>
@@ -29,6 +31,12 @@
                     </div>
                 </div>
             </form>
+
+            <div v-else>
+                <span class="text-danger">
+                    Your current plan doesn't allow you to create more teams, please <a href="{{ url('/settings#/subscription') }}">upgrade your subscription</a>.
+                </span>
+            </div>
         </div>
     </div>
 </spark-create-team>

--- a/resources/views/settings/teams/send-invitation.blade.php
+++ b/resources/views/settings/teams/send-invitation.blade.php
@@ -8,14 +8,16 @@
                 The invitation has been sent!
             </div>
 
-            <form class="form-horizontal" role="form">
+            <form class="form-horizontal" role="form" v-if="canInviteMoreTeamMembers">
                 <!-- E-Mail Address -->
                 <div class="form-group" :class="{'has-error': form.errors.has('email')}">
                     <label class="col-md-4 control-label">E-Mail Address</label>
 
                     <div class="col-md-6">
                         <input type="email" class="form-control" name="email" v-model="form.email">
-
+                        <span class="help-block" v-if="hasTeamMembersLimit">
+                            You currently have @{{ remainingTeamMembers }} invitation(s) remaining.
+                        </span>
                         <span class="help-block" v-show="form.errors.has('email')">
                             @{{ form.errors.get('email') }}
                         </span>
@@ -40,6 +42,12 @@
                     </div>
                 </div>
             </form>
+
+            <div v-else>
+                <span class="text-danger">
+                    Your current plan doesn't allow you to invite more members, please <a href="{{ url('/settings#/subscription') }}">upgrade your subscription</a>.
+                </span>
+            </div>
         </div>
     </div>
 </spark-send-invitation>


### PR DESCRIPTION
It shows a counter for how many teams/invitations you may create:

<img width="544" alt="screen shot 2016-09-28 at 11 19 37 pm" src="https://cloud.githubusercontent.com/assets/4332182/18945076/04e44116-8629-11e6-92ff-2eb67d8a74fa.png">

---

When the limit is reached a message is shown instead of the creation form:

<img width="773" alt="screen shot 2016-09-28 at 11 38 34 pm" src="https://cloud.githubusercontent.com/assets/4332182/18945077/05055bbc-8629-11e6-8ed1-682e9c0aa425.png">
