### PR TITLE
trial ending notification link fix

### DIFF
--- a/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
+++ b/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
@@ -42,7 +42,7 @@ class CreateTrialEndingNotification
             'icon' => 'fa-clock-o',
             'body' => "The ".$event->team->name." team's trial period will expire on ".$event->team->trial_ends_at->format('F jS').'.',
             'action_text' => 'Subscribe',
-            'action_url' => '/settings/teams/'.$event->team->id.'#/subscription',
+            'action_url' => '/settings/'.Spark::teamString().'/'.$event->team->id.'#/subscription',
         ]);
     }
 }


### PR DESCRIPTION
Trial ending notification still has hard coded `/team/` link
