### PR TITLE
Only set XSRF token if it is defined

### DIFF
--- a/resources/assets/js/interceptors.js
+++ b/resources/assets/js/interceptors.js
@@ -1,6 +1,8 @@
 module.exports = (request, next) => {
 
-    request.headers.set('X-XSRF-TOKEN', Cookies.get('XSRF-TOKEN'));
+    if (Cookies.get('XSRF-TOKEN') !== undefined) {
+        request.headers.set('X-XSRF-TOKEN', Cookies.get('XSRF-TOKEN'));
+    }
 
     /**
      * Intercept the incoming responses.


### PR DESCRIPTION
If CRSF is not enabled, do not set XSRF token.

As when undefined is passed to request.headers.set we get  `TypeError: Cannot read property 'replace' of undefined` error
