### PR TITLE
gulp-concat required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "devDependencies": {
-    "gulp": "^3.8.8"
+    "gulp": "^3.8.8",
+    "gulp-concat": "~2.6"
   },
   "dependencies": {
     "bootstrap": "^3.0.0",


### PR DESCRIPTION
A new install of spark failed gulp due to "gulp-concat" not being found.
