### PR TITLE
allow jwt 3.0 for legacy purposes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5.9",
         "erusev/parsedown": "~1.0",
-        "firebase/php-jwt": "~4.0",
+        "firebase/php-jwt": "~3.0|~4.0",
         "guzzlehttp/guzzle": "~6.0",
         "ramsey/uuid": "^3.1",
         "intervention/image": "^2.3"


### PR DESCRIPTION
Some other packages (such as the google api client) are still requiring the `firebase/php-jwt` to be at `~3.0`. 

While there is a [pull request to update those clients](https://github.com/google/google-api-php-client/pull/1063), it would be nice if spark could allow for both if there are no internal conflicts...

Right now anyone using spark that also interacts with a google API can't update for the last ~24 days worth of releases.
