### PR TITLE
Added missing route for fetching team plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /vendor
+/.idea

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -63,6 +63,9 @@ $router->group(['middleware' => 'web'], function ($router) {
 
         // Billing
 
+        // Plans...
+        $router->get('/spark/'.$teamString.'-plans', 'TeamPlanController@all');
+
         // Subscription Settings...
         $router->post('/settings/'.$pluralTeamString.'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@store');
         $router->put('/settings/'.$pluralTeamString.'/{team}/subscription', 'Settings\Teams\Subscription\PlanController@update');


### PR DESCRIPTION
Not sure why this got removed, but it's causing errors when using Team Billing. It looks like perhaps @themsaid missed an update before pushing 0fe9b6335542e8dd188277b4da3f966814b766ff.

Also added the .idea directory to the .gitignore file.
