### PR TITLE
Optional team creation on registeration

### DIFF
--- a/resources/views/auth/register-common-form.blade.php
+++ b/resources/views/auth/register-common-form.blade.php
@@ -1,6 +1,6 @@
 <form class="form-horizontal" role="form">
     <!-- Team Name -->
-    @if (Spark::usesTeams())
+    @if (Spark::teamOnRegistration())
         <div class="form-group" :class="{'has-error': registerForm.errors.has('team')}" v-if=" ! invitation">
             <label class="col-md-4 control-label">{{ ucfirst(Spark::teamString()) }} Name</label>
 

--- a/resources/views/auth/register-common-form.blade.php
+++ b/resources/views/auth/register-common-form.blade.php
@@ -1,6 +1,6 @@
 <form class="form-horizontal" role="form">
     <!-- Team Name -->
-    @if (Spark::teamOnRegistration())
+    @if ((Spark::needsCardUpFront() && Spark::plans()->isEmpty()) || ! Spark::optionalTeams())
         <div class="form-group" :class="{'has-error': registerForm.errors.has('team')}" v-if=" ! invitation">
             <label class="col-md-4 control-label">{{ ucfirst(Spark::teamString()) }} Name</label>
 

--- a/resources/views/nav/teams.blade.php
+++ b/resources/views/nav/teams.blade.php
@@ -24,3 +24,13 @@
         </span>
     </a>
 </li>
+
+@if (Spark::optionalTeams() && Auth::user()->teams()->count() > 0 && auth()->user()->current_team)
+    <li class="divider"></li>
+
+    <li>
+        <a href="/switch-to-user">
+            <img :src="user.photo_url" class="spark-team-photo-xs"><i class="fa fa-btn"></i>Use as {{ auth()->user()->name }}
+        </a>
+    </li>
+@endif

--- a/src/CanJoinTeams.php
+++ b/src/CanJoinTeams.php
@@ -104,7 +104,11 @@ trait CanJoinTeams
      */
     public function currentTeam()
     {
-        if (is_null($this->current_team_id) && $this->hasTeams()) {
+        if (
+            ! Spark::optionalTeams() &&
+            is_null($this->current_team_id) &&
+            $this->hasTeams()
+        ) {
             $this->switchToTeam($this->teams->first());
 
             return $this->currentTeam();

--- a/src/Configuration/ManagesAppOptions.php
+++ b/src/Configuration/ManagesAppOptions.php
@@ -5,34 +5,29 @@ namespace Laravel\Spark\Configuration;
 trait ManagesAppOptions
 {
     /**
-     * Indicates that users must create teams on registration.
+     * Indicates that a users may not have teams.
      *
      * @var bool
      */
-    public static $requireTeamOnRegistration = true;
+    public static $optionalTeams = false;
 
     /**
-     * Determines if users can have to create a team on registration.
+     * Determines if users may not have any teams.
      *
      * @return bool
      */
-    public static function teamOnRegistration()
+    public static function optionalTeams()
     {
-        if (! static::usesTeams()) {
-            return false;
-        }
-
-        return static::$requireTeamOnRegistration ||
-               (static::needsCardUpFront() && static::plans()->isEmpty());
+        return ! static::usesTeams() || static::$optionalTeams;
     }
 
     /**
-     * Indicate that no team is required on registration.
+     * Indicate that having a team is optional.
      *
      * @return void
      */
-    public static function noTeamOnRegistration()
+    public static function makeTeamsOptional()
     {
-        static::$requireTeamOnRegistration = false;
+        static::$optionalTeams = true;
     }
 }

--- a/src/Configuration/ManagesAppOptions.php
+++ b/src/Configuration/ManagesAppOptions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Spark\Configuration;
+
+trait ManagesAppOptions
+{
+    /**
+     * Indicates that users must create teams on registration.
+     *
+     * @var bool
+     */
+    public static $requireTeamOnRegistration = true;
+
+    /**
+     * Determines if users can have to create a team on registration.
+     *
+     * @return bool
+     */
+    public static function teamOnRegistration()
+    {
+        if (! static::usesTeams()) {
+            return false;
+        }
+
+        return static::$requireTeamOnRegistration ||
+               (static::needsCardUpFront() && static::plans()->isEmpty());
+    }
+
+    /**
+     * Indicate that no team is required on registration.
+     *
+     * @return void
+     */
+    public static function noTeamOnRegistration()
+    {
+        static::$requireTeamOnRegistration = false;
+    }
+}

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -43,4 +43,21 @@ class UserController extends Controller
             'last_read_announcements_at' => Carbon::now(),
         ])->save();
     }
+
+    /**
+     * Switch the dashboard to the current user.
+     *
+     * @param  Request  $request
+     * @return Response
+     */
+    public function switchToUser(Request $request)
+    {
+        $user = $request->user();
+
+        $user->current_team_id = null;
+
+        $user->save();
+
+        return back();
+    }
 }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -20,6 +20,7 @@ $router->group(['middleware' => 'web'], function ($router) {
     // Users...
     $router->get('/user/current', 'UserController@current');
     $router->put('/user/last-read-announcements-at', 'UserController@updateLastReadAnnouncementsTimestamp');
+    $router->get('/switch-to-user', 'UserController@switchToUser');
 
     // Notifications
     $router->get('/notifications/recent', 'NotificationController@recent');

--- a/src/Interactions/Auth/CreateUser.php
+++ b/src/Interactions/Auth/CreateUser.php
@@ -16,8 +16,8 @@ class CreateUser implements Contract
     {
         $validator = $this->baseValidator($request);
 
-        $validator->sometimes('team', 'required|max:255', function ($input) {
-            return Spark::usesTeams() && ! isset($input['invitation']);
+        $validator->sometimes('team', 'required|max:255', function ($input){
+            return Spark::teamOnRegistration() && ! isset($input['invitation']);
         });
 
         return $validator;

--- a/src/Interactions/Auth/CreateUser.php
+++ b/src/Interactions/Auth/CreateUser.php
@@ -17,7 +17,12 @@ class CreateUser implements Contract
         $validator = $this->baseValidator($request);
 
         $validator->sometimes('team', 'required|max:255', function ($input){
-            return Spark::teamOnRegistration() && ! isset($input['invitation']);
+            if (isset($input['invitation'])) {
+                return false;
+            }
+
+            return (Spark::needsCardUpFront() && Spark::plans()->isEmpty()) ||
+                   ! Spark::optionalTeams();
         });
 
         return $validator;

--- a/src/Interactions/Auth/Register.php
+++ b/src/Interactions/Auth/Register.php
@@ -42,7 +42,7 @@ class Register implements Contract
     {
         $user = Spark::interact(CreateUserContract::class, [$request]);
 
-        if (Spark::usesTeams()) {
+        if (Spark::usesTeams() && ! empty($request->team)) {
             Spark::interact(self::class.'@configureTeamForNewUser', [$request, $user]);
         }
 

--- a/src/Spark.php
+++ b/src/Spark.php
@@ -7,6 +7,7 @@ class Spark
     use Configuration\CallsInteractions,
         Configuration\ManagesApiOptions,
         Configuration\ManagesAppDetails,
+        Configuration\ManagesAppOptions,
         Configuration\ManagesAvailablePlans,
         Configuration\ManagesAvailableRoles,
         Configuration\ManagesBillingProviders,


### PR DESCRIPTION
Added an option `Spark::noTeamOnRegistration()`, this will prevent the team field from appearing in the registration form.

However, if there are only team plans available and a card upfront is required the field will still show up and is still required despite the value of the new option.
