### PR TITLE
Add Patch Method Helper for AJAX requests

### DIFF
--- a/resources/assets/js/forms/http.js
+++ b/resources/assets/js/forms/http.js
@@ -16,6 +16,14 @@ module.exports = {
 
 
     /**
+     * Helper method for making PATCH HTTP requests.
+     */
+    patch(uri, form) {
+        return Spark.sendForm('patch', uri, form);
+    },
+
+
+    /**
      * Helper method for making DELETE HTTP requests.
      */
     delete(uri, form) {


### PR DESCRIPTION
Adds the PATCH method to the http helpers. 
This is often preferable over the put method when working with models.
