### PR TITLE
Cleaning

### DIFF
--- a/src/Configuration/ManagesAppOptions.php
+++ b/src/Configuration/ManagesAppOptions.php
@@ -71,7 +71,7 @@ trait ManagesAppOptions
     /**
      * Hides the team switcher from the navigation menu.
      *
-     * @return void
+     * @return static
      */
     public static function hideTeamSwitcher()
     {

--- a/src/Configuration/ManagesAppOptions.php
+++ b/src/Configuration/ManagesAppOptions.php
@@ -19,6 +19,20 @@ trait ManagesAppOptions
     public static $showTeamSwitcher = true;
 
     /**
+     * Indicates that users can create additional teams from the dashboard.
+     *
+     * @var bool
+     */
+    public static $createsAdditionalTeams = true;
+
+    /**
+     * The name used in the URI and interface to describe a team.
+     *
+     * @var string
+     */
+    public static $teamString = 'team';
+
+    /**
      * Where to redirect users after authentication.
      *
      * @return string
@@ -78,5 +92,48 @@ trait ManagesAppOptions
         static::$showTeamSwitcher = false;
 
         return new static;
+    }
+
+    /**
+     * Determines if users can create additional teams from dashboard.
+     *
+     * @return bool
+     */
+    public static function createsAdditionalTeams()
+    {
+        return static::$createsAdditionalTeams;
+    }
+
+    /**
+     * Specifies that users cannot create additional teams from dashboard.
+     *
+     * @return static
+     */
+    public static function noAdditionalTeams()
+    {
+        static::$createsAdditionalTeams = false;
+
+        return new static;
+    }
+
+    /**
+     * Get the string used to describe a team.
+     *
+     * @return string
+     */
+    public static function teamString()
+    {
+        return static::$teamString;
+    }
+
+    /**
+     * Set the string used to describe a team.
+     *
+     * @param  string  $string
+     * @return void
+     */
+    public static function referToTeamAs($string)
+    {
+        static::$teamString = $string;
     }
 }

--- a/src/Configuration/ManagesModelOptions.php
+++ b/src/Configuration/ManagesModelOptions.php
@@ -21,20 +21,6 @@ trait ManagesModelOptions
     public static $teamModel = 'App\Team';
 
     /**
-     * Indicates that users can create additional teams from the dashboard.
-     *
-     * @var bool
-     */
-    public static $createsAdditionalTeams = true;
-
-    /**
-     * The name used in the URI and interface to describe a team.
-     *
-     * @var string
-     */
-    public static $teamString = 'team';
-
-    /**
      * Set the user model class name.
      *
      * @param  string  $userModel
@@ -104,48 +90,5 @@ trait ManagesModelOptions
     public static function team()
     {
         return new static::$teamModel;
-    }
-
-    /**
-     * Determines if users can create additional teams from dashboard.
-     *
-     * @return bool
-     */
-    public static function createsAdditionalTeams()
-    {
-        return static::$createsAdditionalTeams;
-    }
-
-    /**
-     * Specifies that users cannot create additional teams from dashboard.
-     *
-     * @return static
-     */
-    public static function noAdditionalTeams()
-    {
-        static::$createsAdditionalTeams = false;
-
-        return new static;
-    }
-
-    /**
-     * Get the string used to describe a team.
-     *
-     * @return string
-     */
-    public static function teamString()
-    {
-        return static::$teamString;
-    }
-
-    /**
-     * Set the string used to describe a team.
-     *
-     * @param  string  $string
-     * @return void
-     */
-    public static function referToTeamAs($string)
-    {
-        static::$teamString = $string;
     }
 }

--- a/src/Configuration/ManagesModelOptions.php
+++ b/src/Configuration/ManagesModelOptions.php
@@ -119,11 +119,13 @@ trait ManagesModelOptions
     /**
      * Specifies that users cannot create additional teams from dashboard.
      *
-     * @return void
+     * @return static
      */
     public static function noAdditionalTeams()
     {
         static::$createsAdditionalTeams = false;
+
+        return new static;
     }
 
     /**


### PR DESCRIPTION
This PR makes `hideTeamSwitcher()` and `noAdditionalTeams()` chainable.

I also here suggest to move some options from the `ManagesModelOptions` trait to the `ManagesAppOptions` trait, the later can work a controller for all the general application options.
