### PR TITLE
Hide team deleting if noAdditionalTeams is on

### DIFF
--- a/resources/views/settings/teams/current-teams.blade.php
+++ b/resources/views/settings/teams/current-teams.blade.php
@@ -58,12 +58,14 @@
                                 </button>
                             </td>
 
-                            <!-- Delete Button -->
-                            <td>
-                                <button class="btn btn-danger-outline" @click="approveTeamDelete(team)" v-if="user.id === team.owner_id">
-                                    <i class="fa fa-times"></i>
-                                </button>
-                            </td>
+                            @if (Spark::createsAdditionalTeams())
+                                <!-- Delete Button -->
+                                <td>
+                                    <button class="btn btn-danger-outline" @click="approveTeamDelete(team)" v-if="user.id === team.owner_id">
+                                        <i class="fa fa-times"></i>
+                                    </button>
+                                </td>
+                            @endif
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
If you can't create additional teams & you deleted the one team you have then you get stuck, this PR solves this issue by preventing deletion if that option is on.
