### PR TITLE
use htmlspecialchars() on parsed notification and announcement bodies

### DIFF
--- a/src/Announcement.php
+++ b/src/Announcement.php
@@ -57,6 +57,6 @@ class Announcement extends Model
      */
     public function getParsedBodyAttribute()
     {
-        return (new Parsedown)->text($this->attributes['body']);
+        return (new Parsedown)->text(htmlspecialchars($this->attributes['body']));
     }
 }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -74,6 +74,6 @@ class Notification extends Model
      */
     public function getParsedBodyAttribute()
     {
-        return (new Parsedown)->text($this->attributes['body']);
+        return (new Parsedown)->text(htmlspecialchars($this->attributes['body']));
     }
 }


### PR DESCRIPTION
Since we use Vue's html directive `<div v-html="notification.parsed_body"></div>` we need to escape HTML characters before handling it to the view.
