### PR TITLE
Update allPlans()

### DIFF
--- a/src/Configuration/ManagesAvailablePlans.php
+++ b/src/Configuration/ManagesAvailablePlans.php
@@ -352,7 +352,7 @@ trait ManagesAvailablePlans
      */
     public static function allPlans()
     {
-        return collect(array_merge(static::$plans, static::$teamPlans));
+        return static::plans()->merge(static::teamPlans());
     }
 
     /**

--- a/src/Http/Controllers/PlanController.php
+++ b/src/Http/Controllers/PlanController.php
@@ -13,6 +13,6 @@ class PlanController extends Controller
      */
     public function all()
     {
-        return response()->json(Spark::plans()->merge(Spark::teamPlans()));
+        return response()->json(Spark::allPlans());
     }
 }


### PR DESCRIPTION
Throughout `ManagesAvailablePlans` it has been updated to use `::plans()` and `::teamPlans()`. This PR is to make it so `::allPlans()` uses those same methods so the resulting collection contains the `type` attribute on each plan.