### PR TITLE
Allow trialing after registration

### DIFF
--- a/resources/assets/js/settings/subscription/subscribe-stripe.js
+++ b/resources/assets/js/settings/subscription/subscribe-stripe.js
@@ -48,7 +48,7 @@ module.exports = {
          * Watch for changes on the entire billing address.
          */
         'currentBillingAddress': function (value) {
-            if (!Spark.collectsEuropeanVat) {
+            if ( ! Spark.collectsEuropeanVat) {
                 return;
             }
 
@@ -85,6 +85,7 @@ module.exports = {
             this.form.vat_id = this.billable.vat_id;
         },
 
+
         /**
          * Determine if the user has subscribed to the given plan before.
          */
@@ -111,9 +112,9 @@ module.exports = {
 
             this.form.startProcessing();
 
-            // Here we will build out the payload to send to Stripe to obtain a card token so
-            // we can create the actual subscription. We will build out this data that has
-            // this credit card number, CVC, etc. and exchange it for a secure token ID.
+             // Here we will build out the payload to send to Stripe to obtain a card token so
+             // we can create the actual subscription. We will build out this data that has
+             // this credit card number, CVC, etc. and exchange it for a secure token ID.
             const payload = {
                 name: this.cardForm.name,
                 number: this.cardForm.number,
@@ -128,16 +129,14 @@ module.exports = {
                 address_country: this.form.country
             };
 
-            // Next, we will send the payload to Stripe and handle the response. If we have a
-            // valid token we can send that to the server and use the token to create this
-            // subscription on the back-end. Otherwise, we will show the error messages.
+             // Next, we will send the payload to Stripe and handle the response. If we have a
+             // valid token we can send that to the server and use the token to create this
+             // subscription on the back-end. Otherwise, we will show the error messages.
             Stripe.card.createToken(payload, (status, response) => {
                 if (response.error) {
-                    this.cardForm.errors.set({
-                        number: [
-                            response.error.message
-                        ]
-                    })
+                    this.cardForm.errors.set({number: [
+                        response.error.message
+                    ]})
 
                     this.form.busy = false;
                 } else {
@@ -194,8 +193,8 @@ module.exports = {
          */
         urlForNewSubscription() {
             return this.billingUser
-                ? '/settings/subscription'
-                : `/settings/${Spark.pluralTeamString}/${this.team.id}/subscription`;
+                            ? '/settings/subscription'
+                            : `/settings/${Spark.pluralTeamString}/${this.team.id}/subscription`;
         },
 
 
@@ -206,12 +205,12 @@ module.exports = {
          */
         currentBillingAddress() {
             return this.form.address +
-                this.form.address_line_2 +
-                this.form.city +
-                this.form.state +
-                this.form.zip +
-                this.form.country +
-                this.form.vat_id;
+                   this.form.address_line_2 +
+                   this.form.city +
+                   this.form.state +
+                   this.form.zip +
+                   this.form.country +
+                   this.form.vat_id;
         }
     }
 };

--- a/resources/assets/js/settings/subscription/subscribe-stripe.js
+++ b/resources/assets/js/settings/subscription/subscribe-stripe.js
@@ -89,7 +89,7 @@ module.exports = {
         /**
          * Determine if the user has subscribed to the given plan before.
          */
-        hasSubscription(plan) {
+        hasSubscribed(plan) {
             return !!_.where(this.billable.subscriptions, {provider_plan: plan.id}).length
         },
 

--- a/resources/assets/js/settings/subscription/subscribe-stripe.js
+++ b/resources/assets/js/settings/subscription/subscribe-stripe.js
@@ -48,7 +48,7 @@ module.exports = {
          * Watch for changes on the entire billing address.
          */
         'currentBillingAddress': function (value) {
-            if ( ! Spark.collectsEuropeanVat) {
+            if (!Spark.collectsEuropeanVat) {
                 return;
             }
 
@@ -85,6 +85,13 @@ module.exports = {
             this.form.vat_id = this.billable.vat_id;
         },
 
+        /**
+         * Determine if the user has subscribed to the given plan before.
+         */
+        hasSubscription(plan) {
+            return !!_.where(this.billable.subscriptions, {provider_plan: plan.id}).length
+        },
+
 
         /**
          * Mark the given plan as selected.
@@ -104,9 +111,9 @@ module.exports = {
 
             this.form.startProcessing();
 
-             // Here we will build out the payload to send to Stripe to obtain a card token so
-             // we can create the actual subscription. We will build out this data that has
-             // this credit card number, CVC, etc. and exchange it for a secure token ID.
+            // Here we will build out the payload to send to Stripe to obtain a card token so
+            // we can create the actual subscription. We will build out this data that has
+            // this credit card number, CVC, etc. and exchange it for a secure token ID.
             const payload = {
                 name: this.cardForm.name,
                 number: this.cardForm.number,
@@ -121,14 +128,16 @@ module.exports = {
                 address_country: this.form.country
             };
 
-             // Next, we will send the payload to Stripe and handle the response. If we have a
-             // valid token we can send that to the server and use the token to create this
-             // subscription on the back-end. Otherwise, we will show the error messages.
+            // Next, we will send the payload to Stripe and handle the response. If we have a
+            // valid token we can send that to the server and use the token to create this
+            // subscription on the back-end. Otherwise, we will show the error messages.
             Stripe.card.createToken(payload, (status, response) => {
                 if (response.error) {
-                    this.cardForm.errors.set({number: [
-                        response.error.message
-                    ]})
+                    this.cardForm.errors.set({
+                        number: [
+                            response.error.message
+                        ]
+                    })
 
                     this.form.busy = false;
                 } else {
@@ -185,8 +194,8 @@ module.exports = {
          */
         urlForNewSubscription() {
             return this.billingUser
-                            ? '/settings/subscription'
-                            : `/settings/${Spark.pluralTeamString}/${this.team.id}/subscription`;
+                ? '/settings/subscription'
+                : `/settings/${Spark.pluralTeamString}/${this.team.id}/subscription`;
         },
 
 
@@ -197,12 +206,12 @@ module.exports = {
          */
         currentBillingAddress() {
             return this.form.address +
-                   this.form.address_line_2 +
-                   this.form.city +
-                   this.form.state +
-                   this.form.zip +
-                   this.form.country +
-                   this.form.vat_id;
+                this.form.address_line_2 +
+                this.form.city +
+                this.form.state +
+                this.form.zip +
+                this.form.country +
+                this.form.vat_id;
         }
     }
 };

--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -75,7 +75,7 @@
 
                     <!-- Trial Days -->
                     <td>
-                        <div class="btn-table-align" v-if="plan.trialDays && ! hasSubscription(plan)">
+                        <div class="btn-table-align" v-if="plan.trialDays && ! hasSubscribed(plan)">
                             @{{ plan.trialDays}} Day Trial
                         </div>
                     </td>

--- a/resources/views/settings/subscription/subscribe-common.blade.php
+++ b/resources/views/settings/subscription/subscribe-common.blade.php
@@ -75,7 +75,7 @@
 
                     <!-- Trial Days -->
                     <td>
-                        <div class="btn-table-align" v-if="plan.trialDays">
+                        <div class="btn-table-align" v-if="plan.trialDays && ! hasSubscription(plan)">
                             @{{ plan.trialDays}} Day Trial
                         </div>
                     </td>

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -53,6 +53,22 @@ trait Billable
     }
 
     /**
+     * Determine if the Stripe model has subscribed before.
+     *
+     * @param  string  $subscription
+     * @param  string|null  $plan
+     * @return bool
+     */
+    public function hasSubscribed($subscription = 'default', $plan = null)
+    {
+        if (is_null($subscription = $this->subscription($subscription))) {
+            return false;
+        }
+
+        return $plan ? $subscription->provider_plan == $plan : true;
+    }
+
+    /**
      * Get the available billing plans for the given entity.
      *
      * @return \Illuminate\Support\Collection

--- a/src/Interactions/Subscribe.php
+++ b/src/Interactions/Subscribe.php
@@ -19,7 +19,7 @@ class Subscribe implements Contract
         // Here we will check if we need to skip trial or set trial days on the subscription
         // when creating it on the provider. By default, we will skip the trial when this
         // interaction isn't from registration since they have already usually trialed.
-        if (! $fromRegistration) {
+        if (! $fromRegistration && $user->hasSubscribed('default', $plan->id)) {
             $subscription->skipTrial();
         } elseif ($plan->trialDays > 0) {
             $subscription->trialDays($plan->trialDays);


### PR DESCRIPTION
This PR will allow clients to trial on a plan that has `trialDays` after they log in, this change covers the following scenario:

1. Signup without card.
2. Subscribe to a plan with trial days (provides card info).
3. Card is only charged after trial is over.