### PR TITLE
Allow for disabling proration

### DIFF
--- a/src/Configuration/ManagesBillingProviders.php
+++ b/src/Configuration/ManagesBillingProviders.php
@@ -14,6 +14,13 @@ trait ManagesBillingProviders
     public static $cardUpFront = true;
 
     /**
+     * Indicates if a plan change should be prorated.
+     *
+     * @var bool
+     */
+    public static $prorate = true;
+
+    /**
      * Indicates the service the application uses for billing.
      *
      * @var bool
@@ -51,6 +58,28 @@ trait ManagesBillingProviders
     public static function noCardUpFront()
     {
         static::$cardUpFront = false;
+
+        return new static;
+    }
+
+    /**
+     * Determine if a plan change should be prorated.
+     *
+     * @return bool
+     */
+    public static function prorates()
+    {
+        return static::$cardUpFront;
+    }
+
+    /**
+     * Indicate that a plan change should not be prorated.
+     *
+     * @return static
+     */
+    public static function noProrate()
+    {
+        static::$prorate = false;
 
         return new static;
     }
@@ -146,7 +175,7 @@ trait ManagesBillingProviders
      *
      * @param  bool  $value
      * @return static
-     * 
+     *
      * @throws \Exception
      */
     public static function collectBillingAddress($value = true)

--- a/src/Http/Controllers/Settings/Subscription/PlanController.php
+++ b/src/Http/Controllers/Settings/Subscription/PlanController.php
@@ -54,9 +54,13 @@ class PlanController extends Controller
         if ($plan->price === 0) {
             return $this->destroy($request);
         } else {
-            $request->user()
-                    ->subscription()
-                    ->swap($request->plan);
+            $subscription = $request->user()->subscription();
+
+            if (Spark::prorates()) {
+                $subscription->swap($request->plan);
+            } else {
+                $subscription->noProrate()->swap($request->plan);
+            }
         }
 
         event(new SubscriptionUpdated(


### PR DESCRIPTION
I've submitted a PR to cashier-braintree to allow setting the prorate flag on and off:
https://github.com/laravel/cashier-braintree/pull/25

Now both cashier and cashier-branitree have the `noProrate()` method that we use in this PR to disable prorating.