### PR TITLE
fix diff check

### DIFF
--- a/resources/assets/js/spark.js
+++ b/resources/assets/js/spark.js
@@ -108,7 +108,7 @@ module.exports = {
             }, 240000);
 
             setInterval(() => {
-                if (this.lastRefreshedApiTokenAt.diff(moment(), 'minutes') >= 5) {
+                if (moment().diff(this.lastRefreshedApiTokenAt, 'minutes') >= 5) {
                     this.refreshApiToken();
                 }
             }, 5000);


### PR DESCRIPTION
The current implementation on this fallback will always return a negative number. This is because you have the `.diff()` firing on the wrong object. Refer to http://momentjs.com/docs/#/displaying/difference/

Right now you have:

`old.diff(new, 'minutes')`

When it should be:

`new.diff(old, 'minutes')`