### PR TITLE
Show message on plan update failure

### DIFF
--- a/resources/assets/js/mixins/subscriptions.js
+++ b/resources/assets/js/mixins/subscriptions.js
@@ -27,7 +27,7 @@ module.exports = {
 
             this.planForm.errors.forget();
 
-            // Here we will send the request to the server to update the subscription plan and
+             // Here we will send the request to the server to update the subscription plan and
              // update the user and team once the request is complete. This method gets used
              // for both updating subscriptions plus resuming any cancelled subscriptions.
             this.$http.put(this.urlForPlanUpdate, {"plan": plan.id})

--- a/resources/assets/js/mixins/subscriptions.js
+++ b/resources/assets/js/mixins/subscriptions.js
@@ -27,7 +27,7 @@ module.exports = {
 
             this.planForm.errors.forget();
 
-             // Here we will send the request to the server to update the subscription plan and
+            // Here we will send the request to the server to update the subscription plan and
              // update the user and team once the request is complete. This method gets used
              // for both updating subscriptions plus resuming any cancelled subscriptions.
             this.$http.put(this.urlForPlanUpdate, {"plan": plan.id})
@@ -36,7 +36,7 @@ module.exports = {
                     Bus.$emit('updateTeam');
                 })
                 .catch(response => {
-                    this.planForm.errors.set(response.data);
+                    this.planForm.errors.set({plan: ["Subscription update failed!"]});
                 })
                 .finally(() => {
                     this.selectingPlan = null;


### PR DESCRIPTION
Currently no errors are returned to the user when the subscription update fails, this PR  shows an error message.

<img width="809" alt="screen shot 2016-11-14 at 3 43 23 pm" src="https://cloud.githubusercontent.com/assets/4332182/20266954/0f72e71e-aa81-11e6-8984-5f8f5ff62c65.png">
