### PR TITLE
Simple update to explain to users where to update terms

### DIFF
--- a/install-stubs/terms.md
+++ b/install-stubs/terms.md
@@ -1,1 +1,3 @@
 Your terms of service.
+  
+To edit these terms, simply edit the `terms.md` file found in the root of your project.


### PR DESCRIPTION
I have seen a few Spark sites now with the default terms file unedited, and I also didn't see anything in the docs about it. This is just a small addition to tell users how and where to edit the terms of the site.