### PR TITLE
Make the invoice ID consistent in downloads

### DIFF
--- a/src/Http/Controllers/Settings/Billing/SendsInvoiceNotifications.php
+++ b/src/Http/Controllers/Settings/Billing/SendsInvoiceNotifications.php
@@ -43,6 +43,11 @@ trait SendsInvoiceNotifications
      */
     protected function buildInvoiceMessage($message, $billable, $invoice, array $invoiceData)
     {
+        $localInvoice = $billable->user()->localInvoices()
+                            ->where('provider_id', $invoice->id)->firstOrFail();
+
+        $invoiceData['id'] = $localInvoice->id;
+
         $message->to($billable->email, $billable->name)
                 ->subject($invoiceData['product'].' Invoice')
                 ->attachData($invoice->pdf($invoiceData), 'invoice.pdf');


### PR DESCRIPTION
Invoices downloaded from the email sent have the `Invoice Number` equal to the invoice number of the provider, however from the download section of spark dashboard the Invoice Number is the raw id of the local invoice.

Here's the line where we force use the row ID in the email invoice:
https://github.com/laravel/spark/blob/3.0/src/Http/Controllers/Settings/Billing/InvoiceController.php#L49