### PR TITLE
Fix showing invitations limit and invitations prop mutation warn

### DIFF
--- a/resources/assets/js/settings/teams/mailed-invitations.js
+++ b/resources/assets/js/settings/teams/mailed-invitations.js
@@ -11,10 +11,6 @@ module.exports = {
                 .then(function() {
                     this.$parent.$emit('updateInvitations');
                 });
-
-            this.invitations = _.reject(
-                this.invitations, i => i.id === invitation.id
-            );
         }
     }
 };

--- a/resources/assets/js/settings/teams/send-invitation.js
+++ b/resources/assets/js/settings/teams/send-invitation.js
@@ -20,12 +20,12 @@ module.exports = {
          * Get the active subscription instance.
          */
         activeSubscription() {
-            if ( ! this.$parent.billable) {
+            if ( ! this.$parent.$parent.billable) {
                 return;
             }
 
             const subscription = _.find(
-                this.$parent.billable.subscriptions,
+                this.$parent.$parent.billable.subscriptions,
                 subscription => subscription.name == 'default'
             );
 

--- a/resources/assets/js/settings/teams/send-invitation.js
+++ b/resources/assets/js/settings/teams/send-invitation.js
@@ -1,5 +1,5 @@
 module.exports = {
-    props: ['user', 'team'],
+    props: ['user', 'team', 'billableType'],
 
     /**
      * The component's data.
@@ -20,12 +20,12 @@ module.exports = {
          * Get the active subscription instance.
          */
         activeSubscription() {
-            if ( ! this.$parent.$parent.billable) {
+            if ( ! this.billable) {
                 return;
             }
 
             const subscription = _.find(
-                this.$parent.$parent.billable.subscriptions,
+                this.billable.subscriptions,
                 subscription => subscription.name == 'default'
             );
 

--- a/resources/assets/js/settings/teams/team-membership.js
+++ b/resources/assets/js/settings/teams/team-membership.js
@@ -1,5 +1,5 @@
 module.exports = {
-    props: ['user', 'team'],
+    props: ['user', 'team', 'billableType'],
 
     /**
      * The component's data.

--- a/resources/views/settings/teams/send-invitation.blade.php
+++ b/resources/views/settings/teams/send-invitation.blade.php
@@ -1,4 +1,4 @@
-<spark-send-invitation :user="user" :team="team" inline-template>
+<spark-send-invitation :user="user" :team="team" :billable-type="billableType" inline-template>
     <div class="panel panel-default">
         <div class="panel-heading">Send Invitation</div>
 

--- a/resources/views/settings/teams/team-membership.blade.php
+++ b/resources/views/settings/teams/team-membership.blade.php
@@ -1,4 +1,4 @@
-<spark-team-membership :user="user" :team="team" inline-template>
+<spark-team-membership :user="user" :team="team" :billable-type="billableType" inline-template>
     <div>
         @if (Auth::user()->ownsTeam($team))
             <!-- Send Invitation -->


### PR DESCRIPTION
**send-invitation.js**

Since `spark-send-invitation` is child of `spark-team-membership`, not `spark-team-settings`, we have to go up by two parents to get `billable` data.

**mailed-invitations.js**

Got a warning: 

> Avoid mutating a prop directly since the value will be overwritten whenever the parent component re-renders. Instead, use a data or computed property based on the prop's value. Prop being mutated: "invitations" 
(found in component <spark-mailed-invitations>)

And therefore removed manipulating with prop data. Data is updated nicely on canceling invitation and adding invitation. 