### PR TITLE
Update team photo via interaction

### DIFF
--- a/src/Contracts/Interactions/Settings/Teams/UpdateTeamPhoto.php
+++ b/src/Contracts/Interactions/Settings/Teams/UpdateTeamPhoto.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Spark\Contracts\Interactions\Settings\Teams;
+
+interface UpdateTeamPhoto
+{
+    /**
+     * Get a validator instance for the given data.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  array  $data
+     * @return \Illuminate\Validation\Validator
+     */
+    public function validator($user, array $data);
+
+    /**
+     * Update the user's profile photo.
+     *
+     * @param  \Laravel\Spark\Team  $team
+     * @param  array  $data
+     * @return \Laravel\Spark\Team
+     */
+    public function handle($team, array $data);
+}

--- a/src/Contracts/Interactions/Settings/Teams/UpdateTeamPhoto.php
+++ b/src/Contracts/Interactions/Settings/Teams/UpdateTeamPhoto.php
@@ -7,14 +7,14 @@ interface UpdateTeamPhoto
     /**
      * Get a validator instance for the given data.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Laravel\Spark\Team  $team
      * @param  array  $data
      * @return \Illuminate\Validation\Validator
      */
-    public function validator($user, array $data);
+    public function validator($team, array $data);
 
     /**
-     * Update the user's profile photo.
+     * Update the teams's photo.
      *
      * @param  \Laravel\Spark\Team  $team
      * @param  array  $data

--- a/src/Http/Controllers/Settings/Teams/TeamPhotoController.php
+++ b/src/Http/Controllers/Settings/Teams/TeamPhotoController.php
@@ -2,30 +2,19 @@
 
 namespace Laravel\Spark\Http\Controllers\Settings\Teams;
 
-use Intervention\Image\ImageManager;
-use Illuminate\Support\Facades\Storage;
 use Laravel\Spark\Http\Controllers\Controller;
+use Laravel\Spark\Contracts\Interactions\Settings\Teams\UpdateTeamPhoto;
 use Laravel\Spark\Http\Requests\Settings\Teams\UpdateTeamPhotoRequest;
 
 class TeamPhotoController extends Controller
 {
     /**
-     * The image manager instance.
-     *
-     * @var ImageManager
-     */
-    protected $images;
-
-    /**
      * Create a new controller instance.
      *
-     * @param  ImageManager  $images
      * @return void
      */
-    public function __construct(ImageManager $images)
+    public function __construct()
     {
-        $this->images = $images;
-
         $this->middleware('auth');
     }
 
@@ -38,36 +27,9 @@ class TeamPhotoController extends Controller
      */
     public function update(UpdateTeamPhotoRequest $request, $team)
     {
-        // We will store the profile photos on the "public" disk, which is a convention
-        // for where to place assets we want to be publicly accessible. Then, we can
-        // grab the URL for the image to store with this user in the database row.
-        $file = $request->file('photo');
-
-        $disk = Storage::disk('public');
-
-        $path = $file->hashName('profiles');
-
-        // We will use an image manipulation library to resize the given team photo and
-        // get it ready for storage. We'll also get the "hash name" of this photo as
-        // it serves as a unique identifier for the image and is safe for storage.
-        $disk->put(
-            $path, $this->toImage($file)
+        $this->interaction(
+            $request, UpdateTeamPhoto::class,
+            [$team, $request->all()]
         );
-
-        $team->forceFill([
-            'photo_url' => $disk->url($path),
-        ])->save();
-    }
-
-    /**
-     * Format the given file into a resized image.
-     *
-     * @param  \Symfony\Component\HttpFoundation\File\UploadedFile  $file
-     * @return string
-     */
-    protected function toImage($file)
-    {
-        return (string) $this->images->make($file->path())
-                            ->fit(300)->encode();
     }
 }

--- a/src/Interactions/Settings/Teams/UpdateTeamPhoto.php
+++ b/src/Interactions/Settings/Teams/UpdateTeamPhoto.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Spark\Interactions\Settings\Teams;
+
+use Intervention\Image\ImageManager;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Spark\Contracts\Interactions\Settings\Teams\UpdateTeamPhoto as Contract;
+
+class UpdateTeamPhoto implements Contract
+{
+    /**
+     * The image manager instance.
+     *
+     * @var ImageManager
+     */
+    protected $images;
+
+    /**
+     * Create a new interaction instance.
+     *
+     * @param  ImageManager  $images
+     * @return void
+     */
+    public function __construct(ImageManager $images)
+    {
+        $this->images = $images;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validator($user, array $data)
+    {
+        return Validator::make($data, [
+            'photo' => 'required|image|max:4000',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($team, array $data)
+    {
+        $file = $data['photo'];
+
+        $path = $file->hashName('profiles');
+
+        // We will store the profile photos on the "public" disk, which is a convention
+        // for where to place assets we want to be publicly accessible. Then, we can
+        // grab the URL for the image to store with this user in the database row.
+        $disk = Storage::disk('public');
+
+        $disk->put(
+            $path, $this->formatImage($file)
+        );
+
+        $team->forceFill([
+            'photo_url' => $disk->url($path),
+        ])->save();
+    }
+
+    /**
+     * Resize an image instance for the given file.
+     *
+     * @param  \SplFileInfo  $file
+     * @return \Intervention\Image\Image
+     */
+    protected function formatImage($file)
+    {
+        return (string) $this->images->make($file->path())
+                            ->fit(300)->encode();
+    }
+}

--- a/src/Interactions/Settings/Teams/UpdateTeamPhoto.php
+++ b/src/Interactions/Settings/Teams/UpdateTeamPhoto.php
@@ -30,7 +30,7 @@ class UpdateTeamPhoto implements Contract
     /**
      * {@inheritdoc}
      */
-    public function validator($user, array $data)
+    public function validator($team, array $data)
     {
         return Validator::make($data, [
             'photo' => 'required|image|max:4000',

--- a/src/Providers/SparkServiceProvider.php
+++ b/src/Providers/SparkServiceProvider.php
@@ -204,6 +204,7 @@ class SparkServiceProvider extends ServiceProvider
             'Contracts\Interactions\Settings\Teams\CreateTeam' => 'Interactions\Settings\Teams\CreateTeam',
             'Contracts\Interactions\Settings\Teams\AddTeamMember' => 'Interactions\Settings\Teams\AddTeamMember',
             'Contracts\Interactions\Settings\Teams\UpdateTeamMember' => 'Interactions\Settings\Teams\UpdateTeamMember',
+            'Contracts\Interactions\Settings\Teams\UpdateTeamPhoto' => 'Interactions\Settings\Teams\UpdateTeamPhoto',
             'Contracts\Interactions\Settings\Teams\SendInvitation' => 'Interactions\Settings\Teams\SendInvitation',
             'Contracts\Interactions\Settings\Security\EnableTwoFactorAuth' => 'Interactions\Settings\Security\EnableTwoFactorAuthUsingAuthy',
             'Contracts\Interactions\Settings\Security\VerifyTwoFactorAuthToken' => 'Interactions\Settings\Security\VerifyTwoFactorAuthTokenUsingAuthy',


### PR DESCRIPTION
In reference to https://github.com/laravel/spark/issues/455

Updating user profile photo is done via a transaction that you can swap, but that's not the case for team photos, this PR makes updating team photos done via an interaction.