### PR TITLE
Use custom team string in invitation alert.

### DIFF
--- a/resources/views/auth/register-common.blade.php
+++ b/resources/views/auth/register-common.blade.php
@@ -24,7 +24,7 @@
 <div class="row" v-if="invitation">
     <div class="col-md-8 col-md-offset-2">
         <div class="alert alert-success">
-            We found your invitation to the <strong>@{{ invitation.team.name }}</strong> team!
+            We found your invitation to the <strong>@{{ invitation.team.name }}</strong> {{ Spark::teamString() }}!
         </div>
     </div>
 </div>


### PR DESCRIPTION
The 'We found your invitation...' alert on the registration screen when arriving via an invitation link still had the word 'team' hard-coded in it.

This commit updates it to use the teamString() function so that it correctly supports the custom 'team' naming option introduced in v2.0.8.