### PR TITLE
Calculate remaining teams from user own teams only

### DIFF
--- a/resources/assets/js/settings/teams/create-team.js
+++ b/resources/assets/js/settings/teams/create-team.js
@@ -66,8 +66,8 @@ module.exports = {
             var ownedTeams = _.filter(this.$parent.teams, {owner_id: this.$parent.billable.id});
 
             return this.activePlan
-                ? this.activePlan.attributes.teams - ownedTeams.length
-                : 0;
+                    ? this.activePlan.attributes.teams - ownedTeams.length
+                    : 0;
         },
 
 

--- a/resources/assets/js/settings/teams/create-team.js
+++ b/resources/assets/js/settings/teams/create-team.js
@@ -63,9 +63,11 @@ module.exports = {
          * Get the remaining teams in the active plan.
          */
         remainingTeams() {
+            var ownedTeams = _.filter(this.$parent.teams, {owner_id: this.$parent.billable.id});
+
             return this.activePlan
-                    ? this.activePlan.attributes.teams - this.$parent.teams.length
-                    : 0;
+                ? this.activePlan.attributes.teams - ownedTeams.length
+                : 0;
         },
 
 
@@ -76,6 +78,7 @@ module.exports = {
             if (! this.hasTeamLimit) {
                 return true;
             }
+
             return this.remainingTeams > 0;
         }
     },


### PR DESCRIPTION
This bug causes the "You can't create more teams" warning appear when the user teams reach the plan's maximum teams, we should compare using the user owned teams only not all teams he belongs to.