### PR TITLE
Fixed marking any notification as read.

### DIFF
--- a/src/Http/Controllers/NotificationController.php
+++ b/src/Http/Controllers/NotificationController.php
@@ -3,7 +3,6 @@
 namespace Laravel\Spark\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Laravel\Spark\Notification;
 use Laravel\Spark\Contracts\Repositories\NotificationRepository;
 use Laravel\Spark\Contracts\Repositories\AnnouncementRepository;
 
@@ -61,6 +60,6 @@ class NotificationController extends Controller
      */
     public function markAsRead(Request $request)
     {
-        Notification::whereIn('id', $request->notifications)->update(['read' => 1]);
+        $request->user()->notifications()->whereIn('id', $request->notifications)->update(['read' => 1]);
     }
 }


### PR DESCRIPTION
Right now, if you pass any list of IDs in on the request you will mark them read. This means you could send a request to this endpoint and mark someone else's notifications as read.

This fix makes sure that you are only marking IDs owned by the authenticated user as read.