### PR TITLE
Show "Email Us" link only if support email set

### DIFF
--- a/resources/views/nav/support.blade.php
+++ b/resources/views/nav/support.blade.php
@@ -1,0 +1,10 @@
+<li class="dropdown-header">Support</li>
+
+<!-- Support -->
+<li>
+    <a @click.prevent="showSupportForm" style="cursor: pointer;">
+        <i class="fa fa-fw fa-btn fa-paper-plane"></i>Email Us
+    </a>
+</li>
+
+<li class="divider"></li>

--- a/resources/views/nav/teams.blade.php
+++ b/resources/views/nav/teams.blade.php
@@ -1,5 +1,3 @@
-<li class="divider"></li>
-
 <!-- Teams -->
 <li class="dropdown-header">{{ ucfirst(str_plural(Spark::teamString())) }}</li>
 
@@ -26,3 +24,5 @@
         </a>
     </li>
 @endif
+
+<li class="divider"></li>

--- a/resources/views/nav/user.blade.php
+++ b/resources/views/nav/user.blade.php
@@ -84,23 +84,17 @@
                                 </a>
                             </li>
 
+                            <li class="divider"></li>
+
                             @if (Spark::usesTeams() && (Spark::createsAdditionalTeams() || Spark::showsTeamSwitcher()))
                                 <!-- Team Settings -->
                                 @include('spark::nav.teams')
                             @endif
 
-                            <li class="divider"></li>
-
-                            <!-- Support -->
-                            <li class="dropdown-header">Support</li>
-
-                            <li>
-                                <a @click.prevent="showSupportForm" style="cursor: pointer;">
-                                    <i class="fa fa-fw fa-btn fa-paper-plane"></i>Email Us
-                                </a>
-                            </li>
-
-                            <li class="divider"></li>
+                            @if (Spark::hasSupportAddress())
+                                <!-- Support -->
+                                @include('spark::nav.support')
+                            @endif
 
                             <!-- Logout -->
                             <li>


### PR DESCRIPTION
If `$sendSupportEmailsTo` is set…

![email-set](https://cloud.githubusercontent.com/assets/1914481/21345029/a73484e4-c6f2-11e6-9af5-06bd3d002916.png)

…the user navigation "Support" section renders:

![menu-email-set](https://cloud.githubusercontent.com/assets/1914481/21345032/a92259f2-c6f2-11e6-892f-03892ea49b60.png)

If `$sendSupportEmailsTo` is **not** set…

![email-null](https://cloud.githubusercontent.com/assets/1914481/21345021/9ee10cc2-c6f2-11e6-86d0-23ead29241e3.png)

…the user navigation "Support" section is **not** rendered:

![menu-email-null](https://cloud.githubusercontent.com/assets/1914481/21345025/a4c1e2a6-c6f2-11e6-80ed-200c98d3c089.png)