### PR TITLE
Remove expired session modal close functionality

### DIFF
--- a/resources/views/modals/session-expired.blade.php
+++ b/resources/views/modals/session-expired.blade.php
@@ -1,5 +1,5 @@
 <!-- Session Expired Modal -->
-<div class="modal fade" id="modal-session-expired" tabindex="-1" role="dialog">
+<div class="modal fade" id="modal-session-expired" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
_Original pull request ([#470](https://github.com/laravel/spark/pull/470)) sent to the wrong branch._

On session expiry, the user can currently click outside or press the escape key to close the expired session modal and continue interacting with the Spark application.

This commit restricts functionality after session expiry to the modal's "Go To Login" button only.