### PR TITLE
Update ChartJS to prevent errors when using newer version in app

### DIFF
--- a/resources/assets/js/kiosk/metrics.js
+++ b/resources/assets/js/kiosk/metrics.js
@@ -176,9 +176,11 @@ module.exports = {
                 options.scaleLabel = scaleLabelFormatter;
             }
 
-            var chart = new Chart(
-                document.getElementById(id).getContext('2d')
-            ).Line(data, options);
+            var chart = new Chart(document.getElementById(id).getContext('2d'), {
+                type: 'line',
+                data: data,
+                options: options
+            });
         },
 
 

--- a/resources/views/kiosk.blade.php
+++ b/resources/views/kiosk.blade.php
@@ -2,7 +2,7 @@
 
 @section('scripts')
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.4.6/mousetrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.1.0/Chart.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
 @endsection
 
 @section('content')


### PR DESCRIPTION
If you use a newer version of ChartJS in your own app then the Kiosk page will produce the following error because of ChartJS syntax changes: "(intermediate value).Line is not a function".