### PR TITLE
Do not create a notification about the trial if it was not started for the team

### DIFF
--- a/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
+++ b/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
@@ -34,7 +34,7 @@ class CreateTrialEndingNotification
      */
     public function handle(TeamCreated $event)
     {
-        if (! Spark::teamTrialDays()) {
+        if (! Spark::teamTrialDays() or $event->team->trial_ends_at === null) {
             return;
         }
 

--- a/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
+++ b/src/Listeners/Teams/Subscription/CreateTrialEndingNotification.php
@@ -34,7 +34,7 @@ class CreateTrialEndingNotification
      */
     public function handle(TeamCreated $event)
     {
-        if (! Spark::teamTrialDays() or $event->team->trial_ends_at === null) {
+        if (! Spark::teamTrialDays() || ! $event->team->trial_ends_at) {
             return;
         }
 


### PR DESCRIPTION
The same fix as in https://github.com/laravel/spark/blob/3.0/src/Listeners/Subscription/CreateTrialEndingNotification.php#L37