### PR TITLE
Update User notification relationship to hasMany

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -3,12 +3,19 @@
 namespace Laravel\Spark;
 
 use Illuminate\Support\Str;
-use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class User extends Authenticatable
 {
-    use Billable, HasApiTokens, Notifiable;
+    use Billable, HasApiTokens;
+    
+    /**
+     * Get the notifications for a user.
+     */    
+    public function notifications()
+    {
+        return $this->hasMany(Notification::class);
+    }
 
     /**
      * Get the profile photo URL attribute.


### PR DESCRIPTION
Currently, the User class uses the trait 'Notifiable', which uses a morphMany relationship via 'notifiable_id' and 'notifiable_type'. However, the notifications table does not take this into consideration. Also, there are several methods in other classes that include a 'user_id' parameter when creating notifications, which does not work with the morphMany relationship.

I figured that either Spark needed a complete overhaul of its Notification component to update to the Laravel 5.3 Notifications, or this quick fix would do the trick.

There seems to be only one place in the codebase where the 'notifications' method is called on a User instance. This is in the 'markAsRead' method of the NotificationController. When this method is called, it causes an exception to be thrown and the notifications don't get marked as read.