### PR TITLE
Fix mark as read notifications query

### DIFF
--- a/src/Http/Controllers/NotificationController.php
+++ b/src/Http/Controllers/NotificationController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Spark\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Laravel\Spark\Notification;
 use Laravel\Spark\Contracts\Repositories\NotificationRepository;
 use Laravel\Spark\Contracts\Repositories\AnnouncementRepository;
 
@@ -60,6 +61,6 @@ class NotificationController extends Controller
      */
     public function markAsRead(Request $request)
     {
-        $request->user()->notifications()->whereIn('id', $request->notifications)->update(['read' => 1]);
+        Notification::whereIn('id', $request->notifications)->whereUserId($request->user()->id)->update(['read' => 1]);
     }
 }

--- a/src/User.php
+++ b/src/User.php
@@ -3,12 +3,12 @@
 namespace Laravel\Spark;
 
 use Illuminate\Support\Str;
-use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\RoutesNotifications;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class User extends Authenticatable
 {
-    use Billable, HasApiTokens, Notifiable;
+    use Billable, HasApiTokens, RoutesNotifications;
 
     /**
      * Get the profile photo URL attribute.


### PR DESCRIPTION
We also remove the notifiable trait since it has the `HasDatabaseNotifications` trait from within which we don't use, instead we use a custom `SparkNotification` channel in case users want to use laravel 5.3 style notifications.

https://spark.laravel.com/docs/3.0/notifications#sending-laravel-53-notifications