### PR TITLE
Only return JSON from RegisterController@register when wantsJson()

### DIFF
--- a/src/Http/Controllers/Auth/RegisterController.php
+++ b/src/Http/Controllers/Auth/RegisterController.php
@@ -61,8 +61,12 @@ class RegisterController extends Controller
 
         event(new UserRegistered($user));
 
-        return response()->json([
-            'redirect' => $this->redirectPath()
-        ]);
+        if ($request->wantsJson()) {
+            return response()->json([
+                'redirect' => $this->redirectPath()
+            ]);
+        }
+
+        return redirect($this->redirectPath());
     }
 }


### PR DESCRIPTION
The standard registration flow with Vue.js uses a JSON response format,
but when users want to bypass Vue and send a form submission to
`/register` the returned JSON doesn't help.

Detect if the incoming request is explicitly requesting JSON before
returning data, otherwise send a redirect header