### PR TITLE
Port to SweetAlert2

### DIFF
--- a/install-stubs/gulpfile.js
+++ b/install-stubs/gulpfile.js
@@ -24,6 +24,6 @@ elixir(function(mix) {
                 ]
             }
         })
-        .copy('node_modules/sweetalert/dist/sweetalert.min.js', 'public/js/sweetalert.min.js')
-        .copy('node_modules/sweetalert/dist/sweetalert.css', 'public/css/sweetalert.css');
+        .copy('node_modules/sweetalert2/dist/sweetalert2.min.js', 'public/js/sweetalert.min.js')
+        .copy('node_modules/sweetalert2/dist/sweetalert2.css', 'public/css/sweetalert.css');
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "laravel-elixir-webpack-official": "^1.0.2",
     "moment": "^2.10.6",
     "promise": "^7.1.1",
-    "sweetalert": "^1.1.3",
+    "sweetalert2": "^6.3.0",
     "underscore": "^1.8.3",
     "urijs": "^1.17.0",
     "vue": "~2.0.1",

--- a/resources/assets/js/spark.js
+++ b/resources/assets/js/spark.js
@@ -224,7 +224,7 @@ module.exports = {
                 type: 'success',
                 showConfirmButton: false,
                 timer: 2000
-            });
+            }).then( function (e) {}, function ( e ) { } );
         }
     },
 


### PR DESCRIPTION
- I've changed package.json and gulpfile.js to reference SweetAlert2. 

- The end filenames are still "sweetalert.min.js" and "sweetalert.css" so the views do not need to be updated. 

- There were no conflicting swal() method calls in the code base. The only instance of Swal in, C:\xampp-root-4\spark\resources\assets\js\spark.js did not have any breaking code so it's a relatively straightforward update. 

Cheers, 
Ash