### PR TITLE
Fixes breaking change with Laravel 5.4 attribute casting

### DIFF
--- a/install-stubs/app/TeamUser.php
+++ b/install-stubs/app/TeamUser.php
@@ -47,7 +47,7 @@ class User extends SparkUser
      * @var array
      */
     protected $casts = [
-        'trial_ends_at' => 'date',
+        'trial_ends_at' => 'datetime',
         'uses_two_factor_auth' => 'boolean',
     ];
 }

--- a/install-stubs/app/User.php
+++ b/install-stubs/app/User.php
@@ -44,7 +44,7 @@ class User extends SparkUser
      * @var array
      */
     protected $casts = [
-        'trial_ends_at' => 'date',
+        'trial_ends_at' => 'datetime',
         'uses_two_factor_auth' => 'boolean',
     ];
 }

--- a/src/Team.php
+++ b/src/Team.php
@@ -48,7 +48,7 @@ class Team extends Model
      */
     protected $casts = [
         'owner_id' => 'int',
-        'trial_ends_at' => 'date',
+        'trial_ends_at' => 'datetime',
     ];
 
     /**

--- a/src/Token.php
+++ b/src/Token.php
@@ -46,8 +46,8 @@ class Token extends Model
     protected $casts = [
         'metadata' => 'array',
         'transient' => 'boolean',
-        'last_used_at' => 'date',
-        'expires_at' => 'date',
+        'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
Per Laravel 5.4 upgrade guide:

> The date cast now converts the column to a Carbon object and calls the startOfDay method on the object. If you would like to preserve the time portion of the date, you should use the datetime cast.

