### PR TITLE
Fix L5.4 compatibility issue

### DIFF
--- a/src/Http/Requests/ValidatesBillingAddresses.php
+++ b/src/Http/Requests/ValidatesBillingAddresses.php
@@ -16,7 +16,7 @@ trait ValidatesBillingAddresses
     {
         $this->mergeCardCountryIntoRequest();
 
-        $validator->mergeRules([
+        $validator->addRules([
             'address' => 'required|max:255',
             'address_line_2' => 'max:255',
             'city' => 'required|max:255',


### PR DESCRIPTION
Since mergeRules was removed in L5.4, change to addRules, which has the same behavior.