### PR TITLE
Fix assignment of tokens and token abilities

### DIFF
--- a/resources/assets/js/settings/api.js
+++ b/resources/assets/js/settings/api.js
@@ -24,7 +24,7 @@ module.exports = {
      */
     created() {
         var self = this;
-        
+
         this.$on('updateTokens', function(){
             self.getTokens();
         });
@@ -37,9 +37,7 @@ module.exports = {
          */
         getTokens() {
             axios.get('/settings/api/tokens')
-                    .then(function(response) {
-                        this.tokens = response.data;
-                    });
+                .then(response => this.tokens = response.data);
         },
 
 
@@ -48,9 +46,7 @@ module.exports = {
          */
         getAvailableAbilities() {
             axios.get('/settings/api/token/abilities')
-                .then(function(response) {
-                    this.availableAbilities = response.data;
-                });
+                .then(response => this.availableAbilities = response.data);
         }
     }
 };


### PR DESCRIPTION
My guess is this came with the switch to Axios. I believe Vue Resource bound `this` inside the returned Promise to the VM's scope and Axios probably doesn't. Changing this to use an arrow function causes a new `this` context to not be created inside the function.