### PR TITLE
Version changes since 4.0.0

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## Version 4.0.2
+
+- Various bug fixes.
+
+## Version 4.0.1
+
+- Fix bug with several JavaScript HTTP calls.
+
+## Version 4.0.0
+
+- Compatibility with Laravel 5.4 / Laravel Mix.
+
 ## Version 3.0.5
 
 - Various bug fixes.

--- a/src/Spark.php
+++ b/src/Spark.php
@@ -19,5 +19,5 @@ class Spark
     /**
      * The Spark version.
      */
-    public static $version = '3.0.5';
+    public static $version = '4.0.3';
 }


### PR DESCRIPTION
# Added next version to Spark.php as it would probably be added with the next tag.

# Updated Changes.md to reflect the changelong since 4.0.0. 
_note:_   _next version to be bumped in changes.md following this pull request._

Not sure how to account for previous tags without correct versions...........Thought I'd take a shot at it though.