### PR TITLE
Proper display of Eligibility messages

### DIFF
--- a/resources/assets/js/mixins/subscriptions.js
+++ b/resources/assets/js/mixins/subscriptions.js
@@ -35,8 +35,12 @@ module.exports = {
                     Bus.$emit('updateUser');
                     Bus.$emit('updateTeam');
                 })
-                .catch(response => {
-                    this.planForm.errors.set({plan: ["We were unable to update your subscription. Please contact customer support."]});
+                .catch(errors => {
+                    if (errors.response.status == 422) {
+                        this.planForm.errors.set(errors.response.data);
+                    } else {
+                        this.planForm.errors.set({plan: ["We were unable to update your subscription. Please contact customer support."]});
+                    }
                 })
                 .finally(() => {
                     this.selectingPlan = null;


### PR DESCRIPTION
This PR checks if there are any validation errors while updating subscription and sets the form errors to these errors, without this the hardcoded message will always appear and messages set via `IneligibleForPlan::because()` won't appear to users.