### PR TITLE
UX Improvement for users who cant create teams

### DIFF
--- a/resources/views/settings/teams/team-settings.blade.php
+++ b/resources/views/settings/teams/team-settings.blade.php
@@ -45,11 +45,19 @@
                                 </li>
 
                                 <!-- View All Teams -->
+                                @if (Spark::createsAdditionalTeams())
                                 <li role="presentation">
                                     <a href="/settings#/{{str_plural(Spark::teamString())}}">
                                         <i class="fa fa-fw fa-btn fa-arrow-left"></i>View All {{ ucfirst(str_plural(Spark::teamString())) }}
                                     </a>
                                 </li>
+                                @else
+                                    <li role="presentation">
+                                        <a href="/settings">
+                                            <i class="fa fa-fw fa-btn fa-arrow-left"></i>Your Settings
+                                        </a>
+                                    </li>
+                                @endif
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Currently even when multi-teams are turned off, when you go to view the team, you can view all your teams, this suggests you can just go back to your profile instead

Currently when you set the team limit to 1, and disable additional teams, when you view your team, there is still a link that says "View all teams"

There will only ever be 1 team, thus making this extra step in the user journey.

By checking if the capabilities of the additional teams, we can streamline the journey allowing them to go straight back to their profile