### PR TITLE
Only attempt photo update if file chosen

### DIFF
--- a/resources/assets/js/settings/profile/update-profile-photo.js
+++ b/resources/assets/js/settings/profile/update-profile-photo.js
@@ -20,22 +20,24 @@ module.exports = {
 
             var self = this;
 
-            this.form.startProcessing();
+            if(this.$refs.photo.files[0]) {
+                this.form.startProcessing();
 
-            // We need to gather a fresh FormData instance with the profile photo appended to
-            // the data so we can POST it up to the server. This will allow us to do async
-            // uploads of the profile photos. We will update the user after this action.
-            axios.post('/settings/photo', this.gatherFormData())
-                .then(
-                    () => {
-                        Bus.$emit('updateUser');
+                // We need to gather a fresh FormData instance with the profile photo appended to
+                // the data so we can POST it up to the server. This will allow us to do async
+                // uploads of the profile photos. We will update the user after this action.
+                axios.post('/settings/photo', this.gatherFormData())
+                    .then(
+                        () => {
+                            Bus.$emit('updateUser');
 
-                        self.form.finishProcessing();
-                    },
-                    (error) => {
-                        self.form.setErrors(error.data.responseJSON);
-                    }
-                );
+                            self.form.finishProcessing();
+                        },
+                        (error) => {
+                            self.form.setErrors(error.data.responseJSON);
+                        }
+                    );
+            }
         },
 
 

--- a/resources/assets/js/settings/teams/update-team-photo.js
+++ b/resources/assets/js/settings/teams/update-team-photo.js
@@ -20,23 +20,25 @@ module.exports = {
 
             var self = this;
 
-            this.form.startProcessing();
+            if(this.$refs.photo.files[0]) {
+                this.form.startProcessing();
 
-            // We need to gather a fresh FormData instance with the profile photo appended to
-            // the data so we can POST it up to the server. This will allow us to do async
-            // uploads of the profile photos. We will update the user after this action.
-            axios.post(this.urlForUpdate, this.gatherFormData())
-                .then(
-                    () => {
-                        Bus.$emit('updateTeam');
-                        Bus.$emit('updateTeams');
+                // We need to gather a fresh FormData instance with the profile photo appended to
+                // the data so we can POST it up to the server. This will allow us to do async
+                // uploads of the profile photos. We will update the user after this action.
+                axios.post(this.urlForUpdate, this.gatherFormData())
+                    .then(
+                        () => {
+                            Bus.$emit('updateTeam');
+                            Bus.$emit('updateTeams');
 
-                        self.form.finishProcessing();
-                    },
-                    (error) => {
-                        self.form.setErrors(error.data.responseJSON);
-                    }
-                );
+                            self.form.finishProcessing();
+                        },
+                        (error) => {
+                            self.form.setErrors(error.data.responseJSON);
+                        }
+                    );
+            }
         },
 
 


### PR DESCRIPTION
Should fix #620 for user photos and group photos.

Before change:
Problem described in the issue above. The update endpoint was being hit even if the user cancelled out of the "choose file" dialog, putting the form in a persistent error state.

After change:
A check is done to ensure the user actually chose a file, before the request is made. As a result, an unnecessary ajax request isn't made and the form doesn't enter an error state.