### PR TITLE
Explicite team index in Team->subscription() relationship

### DIFF
--- a/src/Team.php
+++ b/src/Team.php
@@ -104,7 +104,7 @@ class Team extends Model
      */
     public function subscriptions()
     {
-        return $this->hasMany(TeamSubscription::class)->orderBy('created_at', 'desc');
+        return $this->hasMany(TeamSubscription::class, 'team_id')->orderBy('created_at', 'desc');
     }
 
     /**


### PR DESCRIPTION
Changing team model name in Laravel\Spark\ConfigurationManagesModelOptions::teamModel breaks the relationship if you do not make explicit the index