### PR TITLE
Fix kiosk metric graphs hover values

### DIFF
--- a/resources/assets/js/kiosk/metrics.js
+++ b/resources/assets/js/kiosk/metrics.js
@@ -155,7 +155,7 @@ module.exports = {
          * Draw a chart with the given parameters.
          */
         drawChart(id, days, dataGatherer, scaleLabelFormatter) {
-            var dataset = this.baseChartDataSet;
+            var dataset = JSON.parse(JSON.stringify(this.baseChartDataSet));
 
             dataset.data = _.map(_.last(this.indicators, days), dataGatherer);
 


### PR DESCRIPTION
Currently, when you hover over graph points under metrics you see the values from the last chart on the page (New Users). That is caused by the 'this.baseChartDataSet' object being passed as a reference to the chart that then is updated for all the charts when the function run. This can be resolved by making a deep copy of the object before modifying it and passing it to CharJS.