### PR TITLE
Fixed prorates() in ManagesBillingProviders

### DIFF
--- a/src/Configuration/ManagesBillingProviders.php
+++ b/src/Configuration/ManagesBillingProviders.php
@@ -79,7 +79,7 @@ trait ManagesBillingProviders
      */
     public static function prorates()
     {
-        return static::$cardUpFront;
+        return static::$prorate;
     }
 
     /**


### PR DESCRIPTION
The public prorates() function should have been returning the value of the private $prorate field, but was instead returning the $cardUpFront field value.
I have now changed prorates() to return $prorate.