### PR TITLE
Fix VAT Calculation loopholes

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -101,8 +101,8 @@ trait Billable
 
         $vatCalculator->setBusinessCountryCode(Spark::homeCountry());
 
-        return $vatCalculator->getTaxRateForCountry(
-            $this->card_country, ! empty($this->vat_id)
+        return $vatCalculator->getTaxRateForLocation(
+            $this->card_country, $this->billing_zip, ! empty($this->vat_id)
         ) * 100;
     }
 }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -101,8 +101,14 @@ trait Billable
 
         $vatCalculator->setBusinessCountryCode(Spark::homeCountry());
 
+        try {
+            $isValidVAT = $vatCalculator->isValidVATNumber($this->vat_id);
+        } catch(\Mpociot\VatCalculator\Exceptions\VATCheckUnavailableException $e) {
+            $isValidVAT = false;
+        }
+
         return $vatCalculator->getTaxRateForLocation(
-            $this->card_country, $this->billing_zip, ! empty($this->vat_id)
+            $this->card_country, $this->billing_zip, $isValidVAT
         ) * 100;
     }
 }

--- a/src/Http/Controllers/TaxRateController.php
+++ b/src/Http/Controllers/TaxRateController.php
@@ -15,7 +15,7 @@ class TaxRateController extends Controller
      */
     public function calculate(Request $request)
     {
-        if (! $request->has('city', 'state', 'zip', 'country')) {
+        if (! $request->has('zip', 'country')) {
             return response()->json(['rate' => 0]);
         }
 
@@ -23,8 +23,6 @@ class TaxRateController extends Controller
 
         $user->forceFill([
             'vat_id' => $request->vat_id,
-            'billing_city' => $request->city,
-            'billing_state' => $request->state,
             'billing_zip' => $request->zip,
             'billing_country' => $request->country,
             'card_country' => $request->country,


### PR DESCRIPTION
See issue #718 
-> Use billing_zip (in addition to country) in tax rate calculation to take account of local tax rules exceptions
-> Check VAT number validity, otherwise any user entering a fake number gets a tax exemption
-> No need for city and state in VAT calculation (these fields could then perhaps be removed from registration form?)