### PR TITLE
removed autofocus css property from inputs

### DIFF
--- a/resources/views/auth/register-common-form.blade.php
+++ b/resources/views/auth/register-common-form.blade.php
@@ -5,7 +5,7 @@
             <label class="col-md-4 control-label">{{ ucfirst(Spark::teamString()) }} Name</label>
 
             <div class="col-md-6">
-                <input type="text" class="form-control" name="team" v-model="registerForm.team" autofocus>
+                <input type="text" class="form-control" name="team" v-model="registerForm.team">
 
                 <span class="help-block" v-show="registerForm.errors.has('team')">
                     @{{ registerForm.errors.get('team') }}
@@ -19,7 +19,7 @@
                 <label class="col-md-4 control-label">{{ ucfirst(Spark::teamString()) }} Slug</label>
 
                 <div class="col-md-6">
-                    <input type="text" class="form-control" name="team_slug" v-model="registerForm.team_slug" autofocus>
+                    <input type="text" class="form-control" name="team_slug" v-model="registerForm.team_slug">
 
                     <p class="help-block" v-show=" ! registerForm.errors.has('team_slug')">
                         This slug is used to identify your {{ Spark::teamString() }} in URLs.
@@ -38,7 +38,7 @@
         <label class="col-md-4 control-label">Name</label>
 
         <div class="col-md-6">
-            <input type="text" class="form-control" name="name" v-model="registerForm.name" autofocus>
+            <input type="text" class="form-control" name="name" v-model="registerForm.name">
 
             <span class="help-block" v-show="registerForm.errors.has('name')">
                 @{{ registerForm.errors.get('name') }}


### PR DESCRIPTION
because if you modify the register page it will cause a "jump" to this portion of the form.

Example use case: I added a bootstrap jumbotron to the top of the page before a user signs up and pays with a cc and when the page load it "jumps" to the input fields of the form.