### PR TITLE
Allow `afterLoginRedirectTo` argument to be a function

### DIFF
--- a/src/Configuration/ManagesAppOptions.php
+++ b/src/Configuration/ManagesAppOptions.php
@@ -46,7 +46,7 @@ trait ManagesAppOptions
      */
     public static function afterLoginRedirect()
     {
-        return static::$afterLoginRedirectTo;
+        return value(static::$afterLoginRedirectTo);
     }
 
     /**


### PR DESCRIPTION
When using `Spark::afterLoginRedirectTo()` in a ServiceProvider we cannot reliably use the `route` helper, as the availability of the routes will depend on the order of the ServiceProviders and can even break when caching the routes. In essence, something like `Spark::afterLoginRedirectTo(route('home'))` will break the app.

An easy workaround is to use a function:

```
Spark::afterLoginRedirectTo(function () {
    return route('home');
});
```

This means the route helper will only be called when the redirect is taking place, thus preventing the error of the route not yet being declared. The only catch is that depending on how the redirect is done, this won't work. It works when redirecting after login, for instance, but fails when redirecting after a password reset.
```
redirect()->intended($path);
```
This works because `intended` will eventually call `Arr::get()` with `$path` as default, and the `value` helper will resolve the function. This, on the other hand, fails:
```
redirect($path);
```

If `Spark::afterLoginRedirect()` could resolve the `$path` before returning, it would work whether it's a function or not.