### PR TITLE
Make invoice emails for Teams use full team name

### DIFF
--- a/resources/views/settings/invoices/emails/invoice.blade.php
+++ b/resources/views/settings/invoices/emails/invoice.blade.php
@@ -1,4 +1,8 @@
-Hi {{ explode(' ', $billable->name)[0] }}!
+@if ($billable instanceof Laravel\Spark\Team)
+    Hi {{ $billable->name }}!
+@else
+    Hi {{ explode(' ', $billable->name)[0] }}!
+@endif
 
 <br><br>
 


### PR DESCRIPTION
Currently, an invoice email sent to a company named e.g. "Acme Brick" starts with:
```
Hi Acme!
```
This logic makes perfect sense for sending an email to an individual, where we'd want to greet them by first name. For a company, though, it sounds a wee bit awkward.

This PR adds some logic to the view to determine if the billable entity being invoiced is a team. If so, it uses the full team name for the greeting in the email.