### PR TITLE
Fixed width for modal-header

### DIFF
--- a/resources/assets/less/components/notifications.less
+++ b/resources/assets/less/components/notifications.less
@@ -4,7 +4,7 @@
         border-bottom: 0;
         margin-bottom: 0;
         height: 70px;
-        width: 100%;
+        width: 350px;
         position: fixed;
         z-index: 100;
 


### PR DESCRIPTION
In windows Internet Explorer, the 100% is causing the header to use the calculated width of the whole viewable area rather than that of the parent. This will be very difficult to reproduce since it's a rare thing that any self respecting PHP developer would have windows, let alone internet explorer readily available.  However, those of us building enterprise applications would appreciate this fix to be included in the source as our clients are stuck with IE for quite a long time.

If you managed to get this far and not laugh, please re read the above with a posh English accent and realize I was being facetious. Except for the need to have the width set to 350px, that's completely serious.