### PR TITLE
SparkForm display error message only one character

### DIFF
--- a/resources/assets/js/forms/errors.js
+++ b/resources/assets/js/forms/errors.js
@@ -41,6 +41,9 @@ window.SparkFormErrors = function () {
      */
     this.get = function (field) {
         if (this.has(field)) {
+            if(typeof this.errors[field] === 'string') {
+                return this.errors[field];
+            }
             return this.errors[field][0];
         }
     };


### PR DESCRIPTION
When submit to `/login` with wrong password. Server response:

```json
{
    "email": "These credentials do not match our records."
}
```

SpartForm display only:

```
T
```

Thank you.