### PR TITLE
PHPDoc fix to the return type of Plan::archived

### DIFF
--- a/src/Plan.php
+++ b/src/Plan.php
@@ -194,7 +194,7 @@ class Plan implements JsonSerializable
     /**
      * Indicate that the plan should be archived.
      *
-     * @return bool
+     * @return $this
      */
     public function archived()
     {


### PR DESCRIPTION
PHPDoc return type for `Plan::archived()` is incorrect (`bool` instead of `$this`)