### PR TITLE
Allow "Users Currently Trialing" kiosk metric to show as "Teams Curre…

### DIFF
--- a/resources/views/kiosk/metrics.blade.php
+++ b/resources/views/kiosk/metrics.blade.php
@@ -63,10 +63,14 @@
                 </div>
             </div>
 
-            <!-- Total Trial Users -->
+            <!-- Total Trials -->
             <div class="col-md-6">
                 <div class="panel panel-info">
-                    <div class="panel-heading text-center">Users Currently Trialing</div>
+                    @if(Spark::teamTrialDays())
+                        <div class="panel-heading text-center">Teams Currently Trialing</div>
+                    @else
+                        <div class="panel-heading text-center">Users Currently Trialing</div>
+                    @endif
 
                     <div class="panel-body text-center">
                         <span style="font-size: 24px;">

--- a/src/Http/Controllers/Kiosk/PerformanceIndicatorsController.php
+++ b/src/Http/Controllers/Kiosk/PerformanceIndicatorsController.php
@@ -80,15 +80,17 @@ class PerformanceIndicatorsController extends Controller
     }
 
     /**
-     * Get the number of users who are on a generic trial.
+     * Get the number of users or teams who are on a generic trial.
      *
      * @return Response
      */
-    public function trialUsers()
+    public function trials()
     {
-        return Spark::user()
-                        ->where('trial_ends_at', '>=', Carbon::now())
-                        ->whereDoesntHave('subscriptions')
-                        ->count();
+        $model = Spark::teamTrialDays() ? Spark::team() : Spark::user();
+
+        return $model
+                ->where('trial_ends_at', '>=', Carbon::now())
+                ->whereDoesntHave('subscriptions')
+                ->count();
     }
 }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -150,7 +150,7 @@ $router->group(['middleware' => 'web'], function ($router) {
     $router->get('/spark/kiosk/performance-indicators', 'Kiosk\PerformanceIndicatorsController@all');
     $router->get('/spark/kiosk/performance-indicators/revenue', 'Kiosk\PerformanceIndicatorsController@revenue');
     $router->get('/spark/kiosk/performance-indicators/plans', 'Kiosk\PerformanceIndicatorsController@subscribers');
-    $router->get('/spark/kiosk/performance-indicators/trialing', 'Kiosk\PerformanceIndicatorsController@trialUsers');
+    $router->get('/spark/kiosk/performance-indicators/trialing', 'Kiosk\PerformanceIndicatorsController@trials');
 
     // Kiosk User Profiles...
     $router->get('/spark/kiosk/users/{id}/profile', 'Kiosk\ProfileController@show');


### PR DESCRIPTION
Allow "Users Currently Trialing" kiosk metric to show as "Teams Currently Trialing" if team trials are enabled.

Today, even if teamTrialDays() is set, Kiosk still shows "Users Currently Trialing" with a value of zero in Kiosk. According to [Spark docs](https://spark.laravel.com/docs/4.0/billing#no-credit-card-up-front), it sounds like teamTrialDays() and trialDays() are not supposed to be used at the same time, so I used that for the check.

I already fixed it on my application by replacing that route with my own controller, but an actual fix for potential inclusion if you're interested! Totally fine if not. :) Have a good day!

Before:
<img width="537" alt="before" src="https://user-images.githubusercontent.com/796275/29466701-7bf8aaa2-8403-11e7-974c-a6d0cb22e15f.png">


After:
<img width="536" alt="after" src="https://user-images.githubusercontent.com/796275/29466702-7bfa3282-8403-11e7-81d9-75c9154049b7.png">
