### PR TITLE
Handle L5.5 new “Consistent Exception Handling” format in SparkFormErrors

### DIFF
--- a/resources/assets/js/forms/errors.js
+++ b/resources/assets/js/forms/errors.js
@@ -50,8 +50,8 @@ window.SparkFormErrors = function () {
      * Set the raw errors for the collection.
      */
     this.set = function (errors) {
-        if (typeof errors === 'object') {
-            this.errors = errors;
+        if (errors.errors && (typeof errors.errors === 'object')){
+            this.errors = errors.errors;
         } else {
             this.errors = {'form': ['Something went wrong. Please try again or contact customer support.']};
         }


### PR DESCRIPTION
The new format for validation exception handling created a new "errors" key in the returned JSON from a request to /register. The `this.errors` object was being populated with this newly-formatted object. This change properly populates `this.errors` with the errors object being returned.