### PR TITLE
Update Sweetalert to version 2

### DIFF
--- a/install-stubs/webpack.mix.js
+++ b/install-stubs/webpack.mix.js
@@ -1,5 +1,5 @@
 let mix = require('laravel-mix');
-var path = require('path');
+let path = require('path');
 
 /*
  |--------------------------------------------------------------------------

--- a/install-stubs/webpack.mix.js
+++ b/install-stubs/webpack.mix.js
@@ -14,7 +14,6 @@ var path = require('path');
 
 mix.less('resources/assets/less/app.less', 'public/css')
    .copy('node_modules/sweetalert/dist/sweetalert.min.js', 'public/js/sweetalert.min.js')
-   .copy('node_modules/sweetalert/dist/sweetalert.css', 'public/css/sweetalert.css')
    .js('resources/assets/js/app.js', 'public/js')
    .webpackConfig({
         resolve: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "laravel-mix": "0.*",
     "moment": "^2.10.6",
     "promise": "^7.1.1",
-    "sweetalert": "^1.1.3",
+    "sweetalert" : "^2.0.4",
     "underscore": "^1.8.3",
     "urijs": "^1.17.0",
     "vue": "2.*",

--- a/resources/assets/js/spark.js
+++ b/resources/assets/js/spark.js
@@ -219,11 +219,11 @@ module.exports = {
          */
         showSupportRequestSuccessMessage() {
             swal({
-                title: 'Got It!',
-                text: 'We have received your message and will respond soon!',
-                type: 'success',
-                showConfirmButton: false,
-                timer: 2000
+                title : 'Got It!',
+                text  : 'We have received your message and will respond soon!',
+                icon  : 'success',
+                button: false,
+                timer : 2000
             });
         }
     },

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,7 +13,6 @@
     <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
 
     <!-- CSS -->
-    <link href="/css/sweetalert.css" rel="stylesheet">
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
 
     <!-- Scripts -->


### PR DESCRIPTION
Updated sweetalert to version 2 which does not need any css and only needs JavaScript to be imported. Some of the configuration needs changing and removed the link to css in app.blade.php layout.