### PR TITLE
Error message not shown on throw IneligibleForPlan exception

### DIFF
--- a/resources/assets/js/mixins/subscriptions.js
+++ b/resources/assets/js/mixins/subscriptions.js
@@ -37,7 +37,7 @@ module.exports = {
                 })
                 .catch(errors => {
                     if (errors.response.status == 422) {
-                        this.planForm.errors.set(errors.response.data);
+                        this.planForm.errors.set(errors.response.data.errors);
                     } else {
                         this.planForm.errors.set({plan: ["We were unable to update your subscription. Please contact customer support."]});
                     }


### PR DESCRIPTION
If you swap CheckTeamPlanEligibility and throw a IneligibleForPlan exception with a message,
that message ist not shown because the planForm.errors contains an object with the errors object.