### PR TITLE
Update missing-team.blade.php & update CallsInteractions.php

### DIFF
--- a/resources/views/missing-team.blade.php
+++ b/resources/views/missing-team.blade.php
@@ -8,8 +8,10 @@
                 <div class="panel-heading">Where's Your {{ ucfirst(Spark::teamString()) }}?</div>
 
                 <div class="panel-body">
-                    It looks like you're not part of any {{ Spark::teamString() }}! You can create one in your
-                    <a href="/settings#/{{ str_plural(Spark::teamString()) }}">settings</a>.
+                    It looks like you're not part of any {{ Spark::teamString() }}!
+                    @if (Spark::createsAdditionalTeams()) 
+                        You can create one in your <a href="/settings#/{{ str_plural(Spark::teamString()) }}">settings</a>.
+                    @endif
                 </div>
             </div>
         </div>

--- a/resources/views/missing-team.blade.php
+++ b/resources/views/missing-team.blade.php
@@ -9,8 +9,9 @@
 
                 <div class="panel-body">
                     It looks like you're not part of any {{ Spark::teamString() }}!
+
                     @if (Spark::createsAdditionalTeams()) 
-                        You can create one in your <a href="/settings#/{{ str_plural(Spark::teamString()) }}">settings</a>.
+                        You can create a team in your <a href="/settings#/{{ str_plural(Spark::teamString()) }}">settings</a>.
                     @endif
                 </div>
             </div>

--- a/src/Configuration/CallsInteractions.php
+++ b/src/Configuration/CallsInteractions.php
@@ -109,7 +109,18 @@ trait CallsInteractions
     {
         return static::swap('CreateUser@handle', $callback);
     }
-
+    
+    /**
+     * Register a callback to create new teams.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public static function createTeamsWith($callback)
+    {
+        return static::swap('CreateTeam@handle', $callback);
+    }
+    
     /**
      * Set a callback to be used to check plan eligibility.
      *


### PR DESCRIPTION
Added logic to check if the user can create teams or not and if not to not display the 'You can create one ...' in the `missing-team.blade.php` view. From Issue #848 

---

Added `createTeamsWith` method allowing you to swap out the team creation handle. Ref issue #850