### PR TITLE
Added role support to Team Invitations

### DIFF
--- a/install-stubs/database/migrations/create_invitations_table.php
+++ b/install-stubs/database/migrations/create_invitations_table.php
@@ -16,6 +16,7 @@ class CreateInvitationsTable extends Migration
             $table->string('id')->primary();
             $table->integer('team_id')->index();
             $table->integer('user_id')->nullable()->index();
+            $table->string('role')->nullable();
             $table->string('email');
             $table->string('token', 40)->unique();
             $table->timestamps();

--- a/resources/assets/js/settings/teams/send-invitation.js
+++ b/resources/assets/js/settings/teams/send-invitation.js
@@ -8,8 +8,11 @@ module.exports = {
         return {
             plans: [],
 
+            roles: [],
+
             form: new SparkForm({
-                email: ''
+                email: '',
+                role: Spark.defaultRole
             })
         };
     },
@@ -87,6 +90,8 @@ module.exports = {
      */
     created() {
         this.getPlans();
+
+        this.getRoles();
     },
 
 
@@ -98,6 +103,7 @@ module.exports = {
             Spark.post(`/settings/${Spark.pluralTeamString}/${this.team.id}/invitations`, this.form)
                 .then(() => {
                     this.form.email = '';
+                    this.form.role = Spark.defaultRole;
 
                     this.$parent.$emit('updateInvitations');
                 });
@@ -112,5 +118,15 @@ module.exports = {
                     this.plans = response.data;
                 });
         }
+
+        /**
+         * Get the available member roles.
+         */
+        getRoles() {
+            axios.get(`/settings/${Spark.pluralTeamString}/roles`)
+                .then(response => {
+                    this.roles = response.data;
+                });
+        },
     }
 };

--- a/resources/views/settings/teams/send-invitation.blade.php
+++ b/resources/views/settings/teams/send-invitation.blade.php
@@ -23,6 +23,22 @@
                         </span>
                     </div>
                 </div>
+                
+                <!-- Role -->
+                <div class="form-group" :class="{'has-error': form.errors.has('role')}" v-if="roles.length > 0">
+                    <label class="col-md-4 control-label">Role</label>
+
+                    <div class="col-md-6">
+                        <select class="form-control" v-model="form.role">
+                            <option v-for="role in roles" :value="role.value">
+                                @{{ role.text }}
+                            </option>
+                        </select>
+                        <span class="help-block" v-show="form.errors.has('role')">
+                            @{{ form.errors.get('role') }}
+                        </span>
+                    </div>
+                </div>
 
                 <!-- Send Invitation Button -->
                 <div class="form-group">

--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -28,6 +28,7 @@ trait ProvidesScriptVariables
             'currencySymbol' => Cashier::usesCurrencySymbol(),
             'env' => config('app.env'),
             'roles' => Spark::roles(),
+            'defaultRole' => Spark::defaultRole(),
             'state' => Spark::call(InitialFrontendState::class.'@forUser', [Auth::user()]),
             'stripeKey' => config('services.stripe.key'),
             'teamString' => Spark::teamString(),

--- a/src/Contracts/Interactions/Settings/Teams/SendInvitation.php
+++ b/src/Contracts/Interactions/Settings/Teams/SendInvitation.php
@@ -9,7 +9,8 @@ interface SendInvitation
      *
      * @param  \Laravel\Spark\Team  $team
      * @param  string  $email
+     * @param  string  $role
      * @return \Laravel\Spark\Invitation
      */
-    public function handle($team, $email);
+    public function handle($team, $email, $role = '');
 }

--- a/src/Http/Controllers/Settings/Teams/MailedInvitationController.php
+++ b/src/Http/Controllers/Settings/Teams/MailedInvitationController.php
@@ -55,7 +55,7 @@ class MailedInvitationController extends Controller
      */
     public function store(CreateInvitationRequest $request, $team)
     {
-        Spark::interact(SendInvitation::class, [$team, $request->email]);
+        Spark::interact(SendInvitation::class, [$team, $request->email, $request->role]);
     }
 
     /**

--- a/src/Interactions/Auth/Register.php
+++ b/src/Interactions/Auth/Register.php
@@ -59,7 +59,7 @@ class Register implements Contract
     public function configureTeamForNewUser(RegisterRequest $request, $user)
     {
         if ($invitation = $request->invitation()) {
-            Spark::interact(AddTeamMember::class, [$invitation->team, $user]);
+            Spark::interact(AddTeamMember::class, [$invitation->team, $user, $invitation->role]);
 
             self::$team = $invitation->team;
 

--- a/src/Interactions/Settings/Teams/SendInvitation.php
+++ b/src/Interactions/Settings/Teams/SendInvitation.php
@@ -14,12 +14,14 @@ class SendInvitation implements Contract
     /**
      * {@inheritdoc}
      */
-    public function handle($team, $email)
+    public function handle($team, $email, $role)
     {
         $invitedUser = Spark::user()->where('email', $email)->first();
 
+        $role = array_key_exists($role, Spark::roles()) ? $role : Spark::defaultRole();
+
         $this->emailInvitation(
-            $invitation = $this->createInvitation($team, $email, $invitedUser)
+            $invitation = $this->createInvitation($team, $email, $invitedUser, $role)
         );
 
         if ($invitedUser) {
@@ -47,14 +49,16 @@ class SendInvitation implements Contract
      *
      * @param  \Laravel\Spark\Team  $team
      * @param  string  $email
+     * @param  string  $role
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $invitedUser
      * @return Invitation
      */
-    protected function createInvitation($team, $email, $invitedUser)
+    protected function createInvitation($team, $email, $invitedUser, $role)
     {
         return $team->invitations()->create([
             'id' => Uuid::uuid4(),
             'user_id' => $invitedUser ? $invitedUser->id : null,
+            'role' => $role,
             'email' => $email,
             'token' => str_random(40),
         ]);


### PR DESCRIPTION
- Added role support when inviting a new user to the team
- Added new Spark script variable defaultRole
- Updated the view wiht the role select
- Updated the create_invitations_table migration to include a role field
(this could instead be an update migration to support existing spark
instances in the wild)

Reference Issue #812 