### PR TITLE
Added role support to Team Invitations (6.0 Branch)

### DIFF
--- a/install-stubs/database/migrations/update_invitations_table_with_role.php
+++ b/install-stubs/database/migrations/update_invitations_table_with_role.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invitations', function (Blueprint $table) {
+			$table->string('role')->nullable()->after('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+		Schema::table('invitations', function (Blueprint $table) {
+			$table->dropColumn('role');
+		});
+    }
+}

--- a/resources/assets/js/settings/teams/send-invitation.js
+++ b/resources/assets/js/settings/teams/send-invitation.js
@@ -8,8 +8,11 @@ module.exports = {
         return {
             plans: [],
 
+            roles: [],
+
             form: new SparkForm({
-                email: ''
+                email: '',
+                role: Spark.defaultRole
             })
         };
     },
@@ -87,6 +90,8 @@ module.exports = {
      */
     created() {
         this.getPlans();
+
+        this.getRoles();
     },
 
 
@@ -98,6 +103,7 @@ module.exports = {
             Spark.post(`/settings/${Spark.pluralTeamString}/${this.team.id}/invitations`, this.form)
                 .then(() => {
                     this.form.email = '';
+                    this.role.email = Spark.defaultRole;
 
                     this.$parent.$emit('updateInvitations');
                 });
@@ -110,6 +116,16 @@ module.exports = {
             axios.get('/spark/plans')
                 .then(response => {
                     this.plans = response.data;
+                });
+        },
+
+        /**
+         * Get the available member roles.
+         */
+        getRoles() {
+            axios.get(`/settings/${Spark.pluralTeamString}/roles`)
+                .then(response => {
+                    this.roles = response.data;
                 });
         }
     }

--- a/resources/views/settings/teams/send-invitation.blade.php
+++ b/resources/views/settings/teams/send-invitation.blade.php
@@ -24,6 +24,22 @@
                     </div>
                 </div>
 
+                <!-- Role -->
+                <div class="form-group" :class="{'has-error': form.errors.has('role')}" v-if="roles.length > 0">
+                    <label class="col-md-4 control-label">Role</label>
+
+                    <div class="col-md-6">
+                        <select class="form-control" v-model="form.role">
+                            <option v-for="role in roles" :value="role.value">
+                                @{{ role.text }}
+                            </option>
+                        </select>
+                        <span class="help-block" v-show="form.errors.has('role')">
+                            @{{ form.errors.get('role') }}
+                        </span>
+                    </div>
+                </div>
+
                 <!-- Send Invitation Button -->
                 <div class="form-group row">
                     <div class="offset-md-4 col-md-6">

--- a/src/Configuration/ProvidesScriptVariables.php
+++ b/src/Configuration/ProvidesScriptVariables.php
@@ -28,6 +28,7 @@ trait ProvidesScriptVariables
             'currencySymbol' => Cashier::usesCurrencySymbol(),
             'env' => config('app.env'),
             'roles' => Spark::roles(),
+            'defaultRole' => Spark::defaultRole(),
             'state' => Spark::call(InitialFrontendState::class.'@forUser', [Auth::user()]),
             'stripeKey' => config('services.stripe.key'),
             'teamString' => Spark::teamString(),

--- a/src/Contracts/Interactions/Settings/Teams/SendInvitation.php
+++ b/src/Contracts/Interactions/Settings/Teams/SendInvitation.php
@@ -9,7 +9,8 @@ interface SendInvitation
      *
      * @param  \Laravel\Spark\Team  $team
      * @param  string  $email
+     * @param  string  $role
      * @return \Laravel\Spark\Invitation
      */
-    public function handle($team, $email);
+    public function handle($team, $email, $role = '');
 }

--- a/src/Http/Controllers/Settings/Teams/MailedInvitationController.php
+++ b/src/Http/Controllers/Settings/Teams/MailedInvitationController.php
@@ -55,7 +55,9 @@ class MailedInvitationController extends Controller
      */
     public function store(CreateInvitationRequest $request, $team)
     {
-        Spark::interact(SendInvitation::class, [$team, $request->email]);
+        $role = (!$request->filled('role')) ? Spark::defaultRole() : $request->role;
+
+        Spark::interact(SendInvitation::class, [$team, $request->email, $role]);
     }
 
     /**

--- a/src/Interactions/Auth/Register.php
+++ b/src/Interactions/Auth/Register.php
@@ -59,7 +59,7 @@ class Register implements Contract
     public function configureTeamForNewUser(RegisterRequest $request, $user)
     {
         if ($invitation = $request->invitation()) {
-            Spark::interact(AddTeamMember::class, [$invitation->team, $user]);
+            Spark::interact(AddTeamMember::class, [$invitation->team, $user, $invitation->role]);
 
             self::$team = $invitation->team;
 

--- a/src/Interactions/Settings/Teams/SendInvitation.php
+++ b/src/Interactions/Settings/Teams/SendInvitation.php
@@ -14,12 +14,14 @@ class SendInvitation implements Contract
     /**
      * {@inheritdoc}
      */
-    public function handle($team, $email)
+    public function handle($team, $email, $role)
     {
         $invitedUser = Spark::user()->where('email', $email)->first();
 
+        $role = array_key_exists($role, Spark::roles()) ? $role : Spark::defaultRole();
+
         $this->emailInvitation(
-            $invitation = $this->createInvitation($team, $email, $invitedUser)
+            $invitation = $this->createInvitation($team, $email, $invitedUser, $role)
         );
 
         if ($invitedUser) {
@@ -50,11 +52,12 @@ class SendInvitation implements Contract
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $invitedUser
      * @return Invitation
      */
-    protected function createInvitation($team, $email, $invitedUser)
+    protected function createInvitation($team, $email, $invitedUser, $role)
     {
         return $team->invitations()->create([
             'id' => Uuid::uuid4(),
             'user_id' => $invitedUser ? $invitedUser->id : null,
+            'role' => $role,
             'email' => $email,
             'token' => str_random(40),
         ]);


### PR DESCRIPTION
- Added role support when inviting a new user to the team
- Added new Spark script variable defaultRole
- Updated the view wiht the role select
- Updated the create_invitations_table migration to include a role field
(this could instead be an update migration to support existing spark
instances in the wild)
- Role parameter is optional and will default to the default role if not
specified
- Is now in the 6.0 branch
- Adds role field on invitations table as a migration

Reference Issue #812
Reference old PR #859 

![Screenshot](https://goo.gl/jtVAz7)

There's no other visual items, other than `Settings > Teams > Membership > Send Invitation` which is above.