### PR TITLE
Patch tab-state navigation

### DIFF
--- a/resources/assets/js/mixins/tab-state.js
+++ b/resources/assets/js/mixins/tab-state.js
@@ -52,12 +52,14 @@ module.exports = {
             this.removeActiveClassFromTabs();
 
             const tab = $(`${this.pushStateSelector} a[href="#${hash}"][data-toggle="tab"]`);
-
             if (tab.length > 0) {
                 tab.tab('show');
-            }
 
-            this.broadcastTabChange(hash, parameters);
+                this.broadcastTabChange(hash, parameters);
+            }
+            else {
+                this.activateFirstTab();
+            }
         },
 
 


### PR DESCRIPTION
When using browser-back from a 'hash' to 'first tab' with no hash, it would remove active class from tab-button, and remain on the 'hashed' content.

Steps to reproduce

- Open /home
- Click 'settings'
- Click 'Teams'
- Click browser back button