### PR TITLE
Clarify that user search accepts * as a wildcard

### DIFF
--- a/resources/views/kiosk/users.blade.php
+++ b/resources/views/kiosk/users.blade.php
@@ -10,7 +10,7 @@
                             <div class="col-md-12">
                                 <input type="text" id="kiosk-users-search" class="form-control"
                                         name="search"
-                                        placeholder="Search By Name Or E-Mail Address. Use * as a wildcard."
+                                        placeholder="Search by name or e-mail address. Use * as a wildcard."
                                         v-model="searchForm.query"
                                         @keyup.enter="search">
                             </div>

--- a/resources/views/kiosk/users.blade.php
+++ b/resources/views/kiosk/users.blade.php
@@ -10,7 +10,7 @@
                             <div class="col-md-12">
                                 <input type="text" id="kiosk-users-search" class="form-control"
                                         name="search"
-                                        placeholder="Search by name or e-mail address. Use * as a wildcard."
+                                        placeholder="Search By Name / E-Mail ... * Is Wildcard"
                                         v-model="searchForm.query"
                                         @keyup.enter="search">
                             </div>

--- a/resources/views/kiosk/users.blade.php
+++ b/resources/views/kiosk/users.blade.php
@@ -10,7 +10,7 @@
                             <div class="col-md-12">
                                 <input type="text" id="kiosk-users-search" class="form-control"
                                         name="search"
-                                        placeholder="Search By Name Or E-Mail Address..."
+                                        placeholder="Search By Name Or E-Mail Address. Use * as a wildcard."
                                         v-model="searchForm.query"
                                         @keyup.enter="search">
                             </div>


### PR DESCRIPTION
It's not currently obvious that you can search for e.g. `john*` to find someone whose email address is `john@acme.com`. This hopefully makes it more clear that wildcard search is available.