### PR TITLE
Prevent submit on braintree registration form

### DIFF
--- a/resources/views/auth/register-braintree.blade.php
+++ b/resources/views/auth/register-braintree.blade.php
@@ -60,7 +60,7 @@
                                 <!-- Register Button -->
                                 <div class="form-group">
                                     <div class="col-sm-6 col-sm-offset-4">
-                                        <button type="submit" class="btn btn-primary" :disabled="registerForm.busy">
+                                        <button type="submit" class="btn btn-primary" @click.prevent="register" :disabled="registerForm.busy">
                                             <span v-if="registerForm.busy">
                                                 <i class="fa fa-btn fa-spinner fa-spin"></i>Registering
                                             </span>


### PR DESCRIPTION
I'm sorry that my last pull request hadn't a explanation.
This PR just adds the same form submit prevention as in the [register-stripe.blade.php](https://github.com/laravel/spark/blob/ba5a839d0e711b92280cb86ba947522f7f2e15ec/resources/views/auth/register-stripe.blade.php#L144) file.