### PR TITLE
replace $.extend with Vue.util.extend

### DIFF
--- a/resources/assets/js/auth/register-braintree.js
+++ b/resources/assets/js/auth/register-braintree.js
@@ -19,7 +19,7 @@ module.exports = {
             coupon: null,
             invalidCoupon: false,
 
-            registerForm: $.extend(true, new SparkForm({
+            registerForm: Vue.util.extend(true, new SparkForm({
                 braintree_type: '',
                 braintree_token: '',
                 plan: '',

--- a/resources/assets/js/auth/register-stripe.js
+++ b/resources/assets/js/auth/register-stripe.js
@@ -22,7 +22,7 @@ module.exports = {
             country: null,
             taxRate: 0,
 
-            registerForm: $.extend(true, new SparkForm({
+            registerForm: Vue.util.extend(true, new SparkForm({
                 stripe_token: '',
                 plan: '',
                 team: '',

--- a/resources/assets/js/forms/bootstrap.js
+++ b/resources/assets/js/forms/bootstrap.js
@@ -20,4 +20,4 @@ require('./errors');
 /**
  * Add additional HTTP / form helpers to the Spark object.
  */
-$.extend(Spark, require('./http'));
+Vue.util.extend(Spark, require('./http'));

--- a/resources/assets/js/forms/form.js
+++ b/resources/assets/js/forms/form.js
@@ -4,7 +4,7 @@
 window.SparkForm = function (data) {
     var form = this;
 
-    $.extend(this, data);
+    Vue.util.extend(this, data);
 
     /**
      * Create the form error helper instance.

--- a/resources/assets/js/settings/profile/update-contact-information.js
+++ b/resources/assets/js/settings/profile/update-contact-information.js
@@ -6,7 +6,7 @@ module.exports = {
      */
     data() {
         return {
-            form: $.extend(true, new SparkForm({
+            form: Vue.util.extend(true, new SparkForm({
                 name: '',
                 email: ''
             }), Spark.forms.updateContactInformation)

--- a/resources/assets/js/settings/teams/team-members.js
+++ b/resources/assets/js/settings/teams/team-members.js
@@ -12,7 +12,7 @@ module.exports = {
             updatingTeamMember: null,
             deletingTeamMember: null,
 
-            updateTeamMemberForm: $.extend(true, new SparkForm({
+            updateTeamMemberForm: Vue.util.extend(true, new SparkForm({
                 role: ''
             }), Spark.forms.updateTeamMember),
 


### PR DESCRIPTION
Vue have an undocumented extend function. which does the same as jQuerys $.extend
I tested in my custom spark app and should be an drop in replace. had no errors so fare.

Vue.util.extend()
https://github.com/vuejs/vue/blob/master/src/core/global-api/extend.js

https://api.jquery.com/jquery.extend/ 