### PR TITLE
Update vat.js

### DIFF
--- a/resources/assets/js/mixins/vat.js
+++ b/resources/assets/js/mixins/vat.js
@@ -38,7 +38,7 @@ module.exports = {
          * Get the total plan price including the applicable tax.
          */
         priceWithTax(plan) {
-            return plan.price + this.taxAmount(plan);
+            return parseFloat(plan.price) + this.taxAmount(plan);
         }
     }
 };


### PR DESCRIPTION
Fixed an issue where the priceWithTax function returns the figures combined rather than adding them together.

Currently if the price was 10 and tax was 2 it would return as 102 which is not only wrong but can be hugely confusing when displaying the total on page.