### PR TITLE
Fix kiosk announcements not loading on page load.

### DIFF
--- a/resources/assets/js/kiosk/announcements.js
+++ b/resources/assets/js/kiosk/announcements.js
@@ -30,6 +30,8 @@ module.exports = {
     created() {
         var self = this;
 
+        self.getAnnouncements();
+        
         Bus.$on('sparkHashChanged', function (hash, parameters) {
             if (hash == 'announcements' && self.announcements.length === 0) {
                 self.getAnnouncements();


### PR DESCRIPTION
Not sure if this was set as it is for a reason?

When loading the kiosk announcements page, existing announcements are hidden until you create a new announcement.

